### PR TITLE
fix: relock workflow に workflow_dispatch を追加

### DIFF
--- a/.github/workflows/relock-deps-prs.yml
+++ b/.github/workflows/relock-deps-prs.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - pnpm-lock.yaml
       - package.json
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

`relock-deps-prs.yml` の `paths` フィルタ（`pnpm-lock.yaml` / `package.json`）に変更がない PR のマージ時は自動トリガーされない問題を修正。`workflow_dispatch` を追加して手動実行を可能にする。

## Test plan

- [ ] 本 PR マージ後、Actions タブ → "Relock deps PRs" → "Run workflow" でマスターから手動実行し、open な deps/* PR (#477 / #479 / #480) に `chore: relock after master merge [skip ci]` コミットが追加されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)