### PR TITLE
test(ogp): fetch をスタブして OGP 取得テストを安定化

### DIFF
--- a/test/fixtures/testData.ts
+++ b/test/fixtures/testData.ts
@@ -12,6 +12,21 @@ export const normalLinkDataExpectedResponse: OgpData = {
   ok: true
 }
 
+// normalLinkDataExpectedResponse に対応する OGP タグを含む HTML フィクスチャ。
+// fetch をスタブして HTMLRewriter のパース結果を検証するために利用する
+// （本番ドメインへの実ネットワークアクセスを避け、bot 対策の影響を受けないようにする）。
+export const normalLinkOgpHtml = `<!DOCTYPE html>
+<html>
+<head>
+  <title>幻想サイクル</title>
+  <meta property="og:title" content="幻想サイクル">
+  <meta property="og:image" content="https://blog.gensobunya.net/image/logo.jpg">
+  <meta property="og:description" content="AJOCC ME1レーサーによるロード・MTB・CXの機材運用やレビュー、時々レースレポートを書くブログです">
+  <meta property="og:site_name" content="幻想サイクル">
+</head>
+<body></body>
+</html>`
+
 // Todo: テストパターン追加「og:titleとtitleタグ情報が異なる」
 // Todo: テストパターン追加「og:titleがなくtitleタグ情報で出力」
 // 上記2つのdescription版

--- a/test/services/ogpfetcher.test.ts
+++ b/test/services/ogpfetcher.test.ts
@@ -1,40 +1,135 @@
-import { env } from "cloudflare:test"
-import { expect, test, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 import { getOgpMetaData } from "../../src/server/services/getOgpMetaData"
+import { createMockEnv } from "../helpers/mockData"
 import {
   normalLinkDataExpectedResponse,
+  normalLinkOgpHtml,
   normalLinkUrl
 } from "../fixtures/testData"
 
+// getOgpMetaData は内部でグローバル fetch を直接呼び出すため、テストでは fetch をスタブして
+// 制御された HTML を返す。これにより本番ドメイン (blog.gensobunya.net) への実ネットワーク
+// アクセスを排除し、Cloudflare の bot 対策やサイト内容の変化に左右されない安定したテストにする。
+// 検証対象は HTMLRewriter による OGP タグの抽出ロジックそのものである。
+
+const env = createMockEnv()
 const encodedUrl = encodeURIComponent(normalLinkUrl)
 
-// cloudflare:testから提供されるenvをモック
-const mockEnv = {
-  ...env,
-  ASSETS: {
-    fetch: vi.fn().mockResolvedValue(
-      new Response(
-        `
-      <!DOCTYPE html>
-      <html>
-      <head>
-        <title>幻想サイクル</title>
-        <meta property="og:title" content="幻想サイクル">
-        <meta property="og:image" content="https://blog.gensobunya.net/image/logo.jpg">
-        <meta property="og:description" content="AJOCC ME1レーサーによるロード・MTB・CXの機材運用やレビュー、時々レースレポートを書くブログです">
-        <meta property="og:site_name" content="幻想サイクル">
-      </head>
-      <body></body>
-      </html>
-    `,
-        { status: 200, headers: { "content-type": "text/html" } }
-      )
-    ),
-    connect: vi.fn()
-  }
-} as unknown as Env
+/**
+ * fetch をスタブして任意の HTML / ステータスを返すヘルパー
+ */
+const stubFetch = (body: string, init?: ResponseInit) => {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(body, {
+      status: 200,
+      headers: { "content-type": "text/html" },
+      ...init
+    })
+  )
+  vi.stubGlobal("fetch", fetchMock)
+  return fetchMock
+}
 
-test("URIエンコードされたURLからOGPデータを取得する", async () => {
-  const res = await getOgpMetaData(encodedUrl, mockEnv)
-  expect(res).deep.equal(normalLinkDataExpectedResponse)
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("getOgpMetaData", () => {
+  test("URI エンコードされた URL をデコードして OGP データを取得する", async () => {
+    const fetchMock = stubFetch(normalLinkOgpHtml)
+
+    const res = await getOgpMetaData(encodedUrl, env)
+
+    // デコード済みの URL で fetch されること
+    expect(fetchMock).toHaveBeenCalledWith(normalLinkUrl)
+    expect(res).deep.equal(normalLinkDataExpectedResponse)
+  })
+
+  test("og:title が無い場合は title タグにフォールバックする", async () => {
+    stubFetch(`<!DOCTYPE html>
+<html>
+<head>
+  <title>タイトルタグの値</title>
+  <meta property="og:description" content="説明">
+  <meta property="og:image" content="https://example.com/image.jpg">
+</head>
+<body></body>
+</html>`)
+
+    const res = await getOgpMetaData(normalLinkUrl, env)
+
+    expect(res.ok).toBe(true)
+    expect(res.ogpTitle).toBe("タイトルタグの値")
+  })
+
+  test("og:description が無い場合は meta[name=description] にフォールバックする", async () => {
+    stubFetch(`<!DOCTYPE html>
+<html>
+<head>
+  <title>タイトル</title>
+  <meta name="description" content="meta description の値">
+</head>
+<body></body>
+</html>`)
+
+    const res = await getOgpMetaData(normalLinkUrl, env)
+
+    expect(res.ok).toBe(true)
+    expect(res.ogpDescription).toBe("meta description の値")
+  })
+
+  test("og タグが title / description を meta[name] より優先して上書きする", async () => {
+    // meta[name=description] と og:description の両方が存在する場合、og が優先される
+    stubFetch(`<!DOCTYPE html>
+<html>
+<head>
+  <title>title タグ</title>
+  <meta name="description" content="name description">
+  <meta property="og:title" content="og title">
+  <meta property="og:description" content="og description">
+</head>
+<body></body>
+</html>`)
+
+    const res = await getOgpMetaData(normalLinkUrl, env)
+
+    expect(res.ogpTitle).toBe("og title")
+    expect(res.ogpDescription).toBe("og description")
+  })
+
+  test("403 (bot 対策などでブロック) の場合はエラーレスポンスを返す", async () => {
+    // Cloudflare の bot 対策により取得対象がチャレンジ/403 を返すケースを再現。
+    // 実ネットワークではなくスタブで再現することで、CI が外部状況に依存せず安定する。
+    stubFetch("Forbidden", { status: 403 })
+
+    const res = await getOgpMetaData(normalLinkUrl, env)
+
+    expect(res).deep.equal({
+      ok: false,
+      error: "Query url is not found or invalid."
+    })
+  })
+
+  test("404 の場合はエラーレスポンスを返す", async () => {
+    stubFetch("Not Found", { status: 404 })
+
+    const res = await getOgpMetaData(normalLinkUrl, env)
+
+    expect(res.ok).toBe(false)
+    expect(res.error).toBe("Query url is not found or invalid.")
+  })
+
+  test("fetch が例外を投げた場合はエラーレスポンスを返す", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network down"))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const res = await getOgpMetaData(normalLinkUrl, env)
+
+    expect(res.ok).toBe(false)
+    expect(res.error).toBeDefined()
+  })
 })


### PR DESCRIPTION
## 背景 / 原因

GHA (`lint-test.yml`) の `pnpm test` で OGP 取得テストが失敗していた。

- `test/services/ogpfetcher.test.ts` は `normalLinkUrl = "https://blog.gensobunya.net/"` を対象に **本番ドメインへ実ネットワーク fetch** していた。
- 本番ドメインに Cloudflare の bot 対策がリリースされた結果、CI からの fetch が **403**（チャレンジ/ブロック）を返すようになり、`getOgpMetaData` が `{ ok: false, error: "Query url is not found or invalid." }` を返して固定の期待値と不一致 → 失敗。
- さらに、テストがモックしていた `mockEnv.ASSETS.fetch` は **実際には使われていなかった**（`getOgpMetaData` は `ASSETS` ではなくグローバル `fetch` を直接呼ぶ）。つまり従来テストは「ネットワーク + 本番サイトの内容 + bot 対策」に暗黙依存する不安定なものだった。

ローカル再現:
```
fetching https://blog.gensobunya.net/ is done 403
AssertionError: expected { ok: false, …(1) } to deeply equal { ogpTitle: '幻想サイクル', …(5) }
```

## 変更内容

実ネットワーク依存を排除し、**グローバル `fetch` をスタブ**して制御された HTML を `HTMLRewriter` にパースさせる方式へ変更。検証対象を「本番サイトの可用性」ではなく「OGP タグ抽出ロジック」に固定した。

追加した安定シナリオ（計 7 ケース）:
- URI エンコード URL のデコード + 正しい URL で fetch されること
- 全 OGP タグのパース（既存の期待値フィクスチャを流用）
- `og:title` 欠落時の `<title>` フォールバック
- `og:description` 欠落時の `meta[name=description]` フォールバック
- `og:*` が `meta[name]` を上書きする優先順位
- **403（bot 対策ブロック）** / 404 → エラーレスポンス
- `fetch` 例外 → エラーレスポンス

フィクスチャ (`normalLinkOgpHtml`) は期待値と同期させるため `testData.ts` に集約。

## 確認

- `vitest run test/services/ogpfetcher.test.ts` → 7 passed（ネットワークアクセスなし、17ms）
- `pnpm run test:light` → 29 passed
- prettier / knip クリーン

## 補足

本テストはネットワーク・シークレット不要になったため、将来的に `test:light`（PR サンドボックス）対象へ移すことも可能です。今回はスコープを安定化に絞り、配置は据え置きました。


---
_Generated by [Claude Code](https://claude.ai/code/session_014uM5b7fysBfrA7JxRRYm1n)_