### PR TITLE
chore: pnpm v10 対応（packageManager 追加 + 設定移行）

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -50,7 +50,6 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: 10
           run_install: false
 
       - name: Install Node.js

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "private": true,
   "version": "3.0.0",
+  "packageManager": "pnpm@10.34.3",
   "engines": {
     "node": ">=24.0.0",
     "pnpm": ">=10.16.0"
@@ -72,12 +73,5 @@
     "typescript": "^6.0.3",
     "vitest": "^4.1.9",
     "wrangler": "^4.105.0"
-  },
-  "pnpm": {
-    "peerDependencyRules": {
-      "allowedVersions": {
-        "astro-pagefind>astro": "7"
-      }
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,5 @@
 minimumReleaseAge: 1440
+
+peerDependencyRules:
+  allowedVersions:
+    "astro-pagefind>astro": "7"


### PR DESCRIPTION
## Summary
- `package.json` に `packageManager: "pnpm@10.34.3"` を追加し、Corepack 経由で pnpm v10 系に固定
- pnpm v10 で `package.json` の `pnpm` フィールドが読まれなくなったため、`peerDependencyRules.allowedVersions` を `pnpm-workspace.yaml` へ移行

## Test plan
- [x] `pnpm install` で `pnpm` フィールド非推奨警告が解消されたことを確認
- [x] `pnpm install` が Corepack 経由で pnpm v10.34.3 を使用していることを確認
- [x] `pnpm lint` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMAuseTDuyLdbfzAVCSrdB