### PR TITLE
feat: Amazonストアフロントへの導線を記事末とトップページに追加

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -1,6 +1,7 @@
 ---
 import { Picture } from "astro:assets"
 import logo from "../images/dummy.jpg"
+import { AMAZON_STOREFRONT_URL } from "~/consts"
 import { Content as AboutText } from "./text/about.md"
 ---
 
@@ -22,6 +23,25 @@ import { Content as AboutText } from "./text/about.md"
       >
         <AboutText />
       </div>
+      <a
+        href={AMAZON_STOREFRONT_URL}
+        class="mt-4 inline-flex items-center gap-1.5 rounded-md bg-amazon px-3 py-1.5 text-sm font-bold text-white no-underline hover:opacity-90"
+        target="_blank"
+        rel="sponsored noopener noreferrer"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          width="1em"
+          height="1em"
+          aria-hidden="true"
+          ><path
+            fill="currentColor"
+            d="M21.9 8.89l-1.05-4.37c-.22-.9-1-1.52-1.91-1.52H5.05c-.9 0-1.69.63-1.9 1.52L2.1 8.89c-.24 1.02-.02 2.06.62 2.88c.08.11.19.19.28.29V19c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6.94c.09-.09.2-.18.28-.28c.64-.82.87-1.87.62-2.89m-2.99-3.9l1.05 4.37c.1.42.01.84-.25 1.17c-.14.18-.44.47-.94.47c-.61 0-1.14-.49-1.21-1.14L16.98 5zM13 5h1.96l.54 4.52c.05.39-.07.78-.33 1.07c-.22.26-.54.41-.95.41c-.67 0-1.22-.59-1.22-1.31zM8.49 9.52L9.04 5H11v4.69c0 .72-.55 1.31-1.29 1.31c-.34 0-.65-.15-.89-.41c-.25-.29-.37-.68-.33-1.07m-4.45-.16L5.05 5h1.97l-.58 4.86c-.08.65-.6 1.14-1.21 1.14c-.49 0-.8-.29-.93-.47c-.27-.32-.36-.75-.26-1.17M4 19v-6.03c.08.01.15.03.23.03c.87 0 1.66-.36 2.24-.95c.6.6 1.4.95 2.31.95c.87 0 1.65-.36 2.23-.93c.59.57 1.39.93 2.29.93c.84 0 1.64-.35 2.24-.95c.58.6 1.37.95 2.24.95c.08 0 .15-.02.23-.03V19z"
+          ></path></svg
+        >
+        愛用機材ストアフロント（Amazon）
+      </a>
     </div>
   </div>
 </div>

--- a/src/components/StorefrontCard.astro
+++ b/src/components/StorefrontCard.astro
@@ -1,0 +1,50 @@
+---
+import { AMAZON_STOREFRONT_URL } from "~/consts"
+---
+
+<a
+  href={AMAZON_STOREFRONT_URL}
+  class="no-underline hover:opacity-90"
+  target="_blank"
+  rel="sponsored noopener noreferrer"
+>
+  <div
+    class="not-prose flex overflow-hidden rounded-lg border border-amazon border-3 bg-white shadow-xs"
+  >
+    <div class="flex min-w-0 flex-1 flex-col justify-center p-3 md:p-4">
+      <div class="text-sm font-bold leading-tight text-stone-800 md:text-base">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          width="1em"
+          height="1em"
+          class="inline"
+          aria-hidden="true"
+          ><path
+            fill="currentColor"
+            d="M14 3v2h3.59l-9.83 9.83l1.41 1.41L19 6.41V10h2V3m-2 16H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7h-2z"
+          ></path></svg
+        >
+        愛用機材ストアフロント
+      </div>
+      <div class="mt-1 text-xs leading-relaxed text-secondary md:text-sm">
+        ブログで紹介した機材・アクセサリーのうち、現在使っている製品をジャンル別にまとめています
+      </div>
+    </div>
+    <div
+      class="flex w-24 shrink-0 flex-col items-center justify-center gap-1 bg-amazon p-2 text-white md:w-28"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        class="size-8 md:size-10"
+        aria-hidden="true"
+        ><path
+          fill="currentColor"
+          d="M21.9 8.89l-1.05-4.37c-.22-.9-1-1.52-1.91-1.52H5.05c-.9 0-1.69.63-1.9 1.52L2.1 8.89c-.24 1.02-.02 2.06.62 2.88c.08.11.19.19.28.29V19c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6.94c.09-.09.2-.18.28-.28c.64-.82.87-1.87.62-2.89m-2.99-3.9l1.05 4.37c.1.42.01.84-.25 1.17c-.14.18-.44.47-.94.47c-.61 0-1.14-.49-1.21-1.14L16.98 5zM13 5h1.96l.54 4.52c.05.39-.07.78-.33 1.07c-.22.26-.54.41-.95.41c-.67 0-1.22-.59-1.22-1.31zM8.49 9.52L9.04 5H11v4.69c0 .72-.55 1.31-1.29 1.31c-.34 0-.65-.15-.89-.41c-.25-.29-.37-.68-.33-1.07m-4.45-.16L5.05 5h1.97l-.58 4.86c-.08.65-.6 1.14-1.21 1.14c-.49 0-.8-.29-.93-.47c-.27-.32-.36-.75-.26-1.17M4 19v-6.03c.08.01.15.03.23.03c.87 0 1.66-.36 2.24-.95c.6.6 1.4.95 2.31.95c.87 0 1.65-.36 2.23-.93c.59.57 1.39.93 2.29.93c.84 0 1.64-.35 2.24-.95c.58.6 1.37.95 2.24.95c.08 0 .15-.02.23-.03V19z"
+        ></path></svg
+      >
+      <span class="text-xs font-bold">Amazon</span>
+    </div>
+  </div>
+</a>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -2,6 +2,7 @@ export const SITE_TITLE = "幻想サイクル"
 export const SITE_DESCRIPTION =
   "AJOCC C1レーサーによるロード・MTB・CXの機材運用やレビュー、時々レースレポートを書くブログです"
 export const SITE_URL = "https://blog.gensobunya.net/"
+export const AMAZON_STOREFRONT_URL = "https://www.amazon.co.jp/shop/gensobunya"
 export const PROFILE = {
   social: {
     twitter: "gen_sobunya",

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -6,6 +6,7 @@ import CollapsibleToc from "@components/CollapsibleToc.astro"
 import StickyToc from "@components/jsx/StickyToc"
 import RelatedPosts from "@components/RelatedPosts.astro"
 import Share from "@components/Share.astro"
+import StorefrontCard from "@components/StorefrontCard.astro"
 import type { MarkdownHeading } from "astro"
 import { formatInTimeZone } from "date-fns-tz"
 import { SITE_TITLE } from "~/consts"
@@ -60,6 +61,11 @@ const ogpStaticImage = cover
               class="prose prose-base mx-auto max-w-none text-gray-700 prose-p:leading-relaxed prose-p:mb-6 md:prose-lg [&_.twitter-tweet]:mx-auto [&_iframe]:mx-auto [&_iframe]:max-w-full"
             >
               <slot />
+            </div>
+
+            <!-- 愛用機材ストアフロント導線 -->
+            <div class="mt-8">
+              <StorefrontCard />
             </div>
 
             <!-- シェアボタンエリア -->

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -63,14 +63,14 @@ const ogpStaticImage = cover
               <slot />
             </div>
 
-            <!-- 愛用機材ストアフロント導線 -->
-            <div class="mt-8">
-              <StorefrontCard />
-            </div>
-
             <!-- シェアボタンエリア -->
             <div class="mt-8 border-t border-gray-200 py-4">
               <Share url={Astro.url.href} title={title} />
+            </div>
+
+            <!-- 愛用機材ストアフロント導線 -->
+            <div class="mt-4">
+              <StorefrontCard />
             </div>
           </div>
         </article>


### PR DESCRIPTION
## 概要

Amazonアフィリエイトのストアフロント（https://www.amazon.co.jp/shop/gensobunya ）への導線を追加します。

## 変更内容

### 記事末（全記事共通）
- `StorefrontCard.astro` を新設し、`BlogPost.astro` の本文直後・シェアボタンの上に配置
- 既存の `Amzn` 商品カードと同じ「amazon色3pxボーダー = Amazonへ向かうリンク」の視覚言語を踏襲
- 商品画像スロットの位置をオレンジのソリッドパネル＋ストアフロントアイコン（Material Icons storefront）に置き換え、単品商品カードとの区別を構造で表現

### トップページ
- 情報密度を増やさないため新規セクションは追加せず、`About.astro` の著者紹介文の下にボタン型リンクを追加

### その他
- ストアフロントURLは `consts.ts` の `AMAZON_STOREFRONT_URL` に一元管理
- アフィリエイトリンクのため `rel="sponsored noopener noreferrer"` を付与（Google推奨）

## 確認済み事項

- `pnpm lint:fix` / `pnpm lint:unused`（Knip）: エラーなし
- `pnpm test:light`: 74件すべて通過
- ローカル dev サーバーで記事ページ（デスクトップ・375px幅）とトップページの表示を目視確認、コンソールエラー0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcQvr7xJCopxepLrvZJYfW