### PR TITLE
feat: 記事ページのデスクトップ組版をミニマルデザインに改修

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -10,6 +10,7 @@
   "ignoreFiles": [
     "src/components/mdx/Amzn.astro",
     "src/components/mdx/AmznServer.astro",
+    "src/components/mdx/cardStyles.ts",
     "src/components/mdx/LinkCard.astro",
     "src/components/mdx/LinkCardServer.astro",
     "src/components/mdx/SimpleLinkCard.astro",

--- a/src/components/BlogTitle.astro
+++ b/src/components/BlogTitle.astro
@@ -36,7 +36,7 @@ const { cover, title, date, tags } = Astro.props
         ))
       }
     </div>
-    <h1 class="max-w-4xl text-xl font-bold text-white md:text-2xl">
+    <h1 class="max-w-4xl text-xl font-bold text-white md:text-3xl">
       {title}
     </h1>
     <div class="mt-2 text-sm text-white" data-pagefind-ignore>

--- a/src/components/StorefrontCard.astro
+++ b/src/components/StorefrontCard.astro
@@ -9,7 +9,7 @@ import { AMAZON_STOREFRONT_URL } from "~/consts"
   rel="sponsored noopener noreferrer"
 >
   <div
-    class="not-prose flex overflow-hidden rounded-lg border border-amazon border-3 bg-white shadow-xs"
+    class="not-prose flex overflow-hidden rounded-lg border border-stone-200 bg-white shadow-xs"
   >
     <div class="flex min-w-0 flex-1 flex-col justify-center p-3 md:p-4">
       <div class="text-sm font-bold leading-tight text-stone-800 md:text-base">

--- a/src/components/jsx/StickyToc.tsx
+++ b/src/components/jsx/StickyToc.tsx
@@ -92,7 +92,7 @@ export default function StickyToc({ headings }: Props) {
                 className={`block transition-colors focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ${
                   isActive
                     ? "font-semibold text-primary"
-                    : "text-gray-600 hover:text-primary"
+                    : "text-stone-400 hover:text-primary"
                 }`}
                 aria-current={isActive ? "location" : undefined}
               >

--- a/src/components/mdx/Amzn.astro
+++ b/src/components/mdx/Amzn.astro
@@ -9,7 +9,7 @@ interface Props {
 <AmznServer {...Astro.props} server:defer>
   <div
     slot="fallback"
-    class="not-prose relative my-4 h-28 animate-pulse rounded-lg border border-3 border-amazon bg-stone-100 md:h-36"
+    class="not-prose relative my-4 h-28 animate-pulse rounded-lg border border-stone-200 bg-stone-100 md:h-36"
   >
   </div>
 </AmznServer>

--- a/src/components/mdx/AmznServer.astro
+++ b/src/components/mdx/AmznServer.astro
@@ -6,6 +6,7 @@ import {
   createSlackLoggerAdapter
 } from "../../server/adapters/amazonAdapter"
 import { isValidAsin } from "../../server/domain/validators"
+import { linkCardBadge, linkCardFrame } from "./cardStyles"
 
 interface Props {
   asin: string
@@ -91,13 +92,9 @@ try {
   target="_blank"
   rel="noopener noreferrer"
 >
-  <div
-    class="not-prose relative my-4 flex overflow-hidden rounded-lg border border-stone-200 bg-white shadow-xs"
-  >
+  <div class={linkCardFrame}>
     <div class="flex min-w-0 flex-1 flex-col justify-center p-2">
-      <div class="absolute right-2 top-1 text-xs font-medium text-amazon">
-        Amazon
-      </div>
+      <div class={`${linkCardBadge} text-amazon`}>Amazon</div>
       <div
         class="line-clamp-2 text-sm font-bold leading-tight text-stone-800 md:text-base"
       >

--- a/src/components/mdx/AmznServer.astro
+++ b/src/components/mdx/AmznServer.astro
@@ -92,12 +92,10 @@ try {
   rel="noopener noreferrer"
 >
   <div
-    class="not-prose relative my-4 flex overflow-hidden rounded-lg border border-amazon border-3 bg-white shadow-xs"
+    class="not-prose relative my-4 flex overflow-hidden rounded-lg border border-stone-200 bg-white shadow-xs"
   >
     <div class="flex min-w-0 flex-1 flex-col justify-center p-2">
-      <div
-        class="absolute right-0 top-0 bg-amazon rounded-bl px-2 py-1 text-xs text-white"
-      >
+      <div class="absolute right-2 top-1 text-xs font-medium text-amazon">
         Amazon
       </div>
       <div

--- a/src/components/mdx/LinkCardServer.astro
+++ b/src/components/mdx/LinkCardServer.astro
@@ -3,6 +3,7 @@ import { env } from "cloudflare:workers"
 import { createOgpKVCacheAdapter } from "../../server/adapters/ogpAdapter"
 import { getOgpMetaData } from "../../server/services/getOgpMetaData"
 import { isValidUrl } from "../../server/domain/validators"
+import { brandColorText, linkCardBadge, linkCardFrame } from "./cardStyles"
 
 interface Props {
   url: string
@@ -24,12 +25,6 @@ const brandTheme = url.includes("yahoo.co.jp")
   : url.includes("rakuten.co.jp")
     ? "rakuten"
     : null
-
-const brandColorText: Record<string, string> = {
-  amazon: "text-amazon",
-  rakuten: "text-rakuten",
-  yahoo: "text-yahoo"
-}
 
 // OGPデータ取得（KVキャッシュ付き）
 let ogpTitle: string = url
@@ -83,15 +78,11 @@ const isExternal = parsedTargetUrl.hostname !== "blog.gensobunya.net"
   target="_blank"
   rel="noopener noreferrer"
 >
-  <div
-    class="not-prose relative my-4 flex overflow-hidden rounded-lg border border-stone-200 bg-white shadow-xs"
-  >
+  <div class={linkCardFrame}>
     <div class="flex flex-1 flex-col justify-center p-3 min-w-0">
       {
         brandTheme && (
-          <div
-            class={`absolute right-2 top-1 text-xs font-medium ${brandColorText[brandTheme]}`}
-          >
+          <div class={`${linkCardBadge} ${brandColorText[brandTheme]}`}>
             {brandTheme.charAt(0).toUpperCase() + brandTheme.slice(1)}
           </div>
         )

--- a/src/components/mdx/LinkCardServer.astro
+++ b/src/components/mdx/LinkCardServer.astro
@@ -25,15 +25,10 @@ const brandTheme = url.includes("yahoo.co.jp")
     ? "rakuten"
     : null
 
-const brandColorBorder: Record<string, string> = {
-  amazon: "border-amazon border-3",
-  rakuten: "border-rakuten border-3",
-  yahoo: "border-yahoo border-3"
-}
-const brandColorBackground: Record<string, string> = {
-  amazon: "bg-amazon",
-  rakuten: "bg-rakuten",
-  yahoo: "bg-yahoo"
+const brandColorText: Record<string, string> = {
+  amazon: "text-amazon",
+  rakuten: "text-rakuten",
+  yahoo: "text-yahoo"
 }
 
 // OGPデータ取得（KVキャッシュ付き）
@@ -89,13 +84,13 @@ const isExternal = parsedTargetUrl.hostname !== "blog.gensobunya.net"
   rel="noopener noreferrer"
 >
   <div
-    class={`not-prose relative my-4 flex overflow-hidden rounded-lg border bg-white shadow-xs ${brandTheme ? brandColorBorder[brandTheme] : "border-stone-200"}`}
+    class="not-prose relative my-4 flex overflow-hidden rounded-lg border border-stone-200 bg-white shadow-xs"
   >
     <div class="flex flex-1 flex-col justify-center p-3 min-w-0">
       {
         brandTheme && (
           <div
-            class={`absolute right-0 top-0 ${brandColorBackground[brandTheme]} rounded-bl px-2 py-1 text-xs text-white`}
+            class={`absolute right-2 top-1 text-xs font-medium ${brandColorText[brandTheme]}`}
           >
             {brandTheme.charAt(0).toUpperCase() + brandTheme.slice(1)}
           </div>

--- a/src/components/mdx/MdxA.astro
+++ b/src/components/mdx/MdxA.astro
@@ -7,6 +7,11 @@ interface Props {
 const { href, target, rel } = Astro.props
 ---
 
-<a href={href} target={target} rel={rel} class="text-primary hover:underline">
+<a
+  href={href}
+  target={target}
+  rel={rel}
+  class="underline decoration-stone-400 underline-offset-4 transition-colors hover:text-primary hover:decoration-primary"
+>
   <slot />
 </a>

--- a/src/components/mdx/MdxBlockQuote.astro
+++ b/src/components/mdx/MdxBlockQuote.astro
@@ -2,8 +2,6 @@
 
 ---
 
-<blockquote
-  class="mx-4 border-l-4 border-amber-300 bg-amber-50 px-4 py-3 italic"
->
+<blockquote class="border-l-2 border-stone-300 pl-4 text-stone-500">
   <slot />
 </blockquote>

--- a/src/components/mdx/MdxBlockQuote.astro
+++ b/src/components/mdx/MdxBlockQuote.astro
@@ -2,6 +2,6 @@
 
 ---
 
-<blockquote class="border-l-2 border-stone-300 pl-4 text-stone-500">
+<blockquote class="border-l-2 border-stone-300 pl-4 text-secondary">
   <slot />
 </blockquote>

--- a/src/components/mdx/MdxH2.astro
+++ b/src/components/mdx/MdxH2.astro
@@ -5,6 +5,6 @@ interface Props {
 const { id } = Astro.props
 ---
 
-<h2 id={id} class="mt-14 mb-5 text-2xl leading-normal font-bold text-gray-900">
+<h2 id={id} class="mt-14 mb-5 text-2xl leading-normal font-bold text-stone-900">
   <slot />
 </h2>

--- a/src/components/mdx/MdxH2.astro
+++ b/src/components/mdx/MdxH2.astro
@@ -5,9 +5,6 @@ interface Props {
 const { id } = Astro.props
 ---
 
-<h2
-  id={id}
-  class="my-8 border-l-4 border-accent py-1 pl-4 text-xl font-bold text-gray-800"
->
+<h2 id={id} class="mt-14 mb-5 text-2xl leading-normal font-bold text-gray-900">
   <slot />
 </h2>

--- a/src/components/mdx/MdxH3.astro
+++ b/src/components/mdx/MdxH3.astro
@@ -5,6 +5,6 @@ interface Props {
 const { id } = Astro.props
 ---
 
-<h3 id={id} class="mt-10 mb-4 text-xl leading-normal font-bold text-gray-900">
+<h3 id={id} class="mt-10 mb-4 text-xl leading-normal font-bold text-stone-900">
   <slot />
 </h3>

--- a/src/components/mdx/MdxH3.astro
+++ b/src/components/mdx/MdxH3.astro
@@ -5,9 +5,6 @@ interface Props {
 const { id } = Astro.props
 ---
 
-<h3
-  id={id}
-  class="my-6 border-b border-gray-300 pb-2 text-lg font-semibold text-gray-800"
->
+<h3 id={id} class="mt-10 mb-4 text-xl leading-normal font-bold text-gray-900">
   <slot />
 </h3>

--- a/src/components/mdx/MdxH4.astro
+++ b/src/components/mdx/MdxH4.astro
@@ -5,6 +5,6 @@ interface Props {
 const { id } = Astro.props
 ---
 
-<h4 id={id} class="mt-8 mb-3 text-[1.0625rem] font-bold text-gray-900">
+<h4 id={id} class="text-article mt-8 mb-3 font-bold text-stone-900">
   <slot />
 </h4>

--- a/src/components/mdx/MdxH4.astro
+++ b/src/components/mdx/MdxH4.astro
@@ -5,6 +5,6 @@ interface Props {
 const { id } = Astro.props
 ---
 
-<h4 id={id} class="my-4 text-base font-semibold text-gray-800">
+<h4 id={id} class="mt-8 mb-3 text-[1.0625rem] font-bold text-gray-900">
   <slot />
 </h4>

--- a/src/components/mdx/MdxStrong.astro
+++ b/src/components/mdx/MdxStrong.astro
@@ -2,6 +2,6 @@
 
 ---
 
-<strong class="font-bold underline decoration-amber-400/40 decoration-4">
+<strong class="font-bold">
   <slot />
 </strong>

--- a/src/components/mdx/cardStyles.ts
+++ b/src/components/mdx/cardStyles.ts
@@ -1,0 +1,9 @@
+export const linkCardFrame =
+  "not-prose relative my-4 flex overflow-hidden rounded-lg border border-stone-200 bg-white shadow-xs"
+
+export const linkCardBadge = "absolute right-2 top-1 text-xs font-medium"
+
+export const brandColorText = {
+  rakuten: "text-rakuten",
+  yahoo: "text-yahoo"
+} as const

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -37,12 +37,13 @@ const ogpStaticImage = cover
   description={description.trim()}
   twitterImage={twitterOgpImageUrl}
   markdownUrl={markdownUrl}
+  bodyBackground="bg-white"
 >
   <!-- デスクトップビューで2カラムレイアウト -->
   <div class="flex gap-8">
     <!-- メインコンテンツ -->
     <main class="min-w-0 flex-1">
-      <div class="mb-8 overflow-hidden bg-white shadow-xs sm:rounded-lg">
+      <div class="mb-8">
         <article data-pagefind-body>
           <BlogTitle
             title={title}
@@ -58,13 +59,13 @@ const ogpStaticImage = cover
             </div>
 
             <div
-              class="prose prose-base mx-auto max-w-none text-gray-700 prose-p:leading-relaxed prose-p:mb-6 md:prose-lg [&_.twitter-tweet]:mx-auto [&_iframe]:mx-auto [&_iframe]:max-w-full"
+              class="prose prose-base mx-auto max-w-[40rem] text-gray-800 prose-p:leading-relaxed prose-p:mb-6 md:text-[1.0625rem] md:leading-[2] md:tracking-[0.015em] md:prose-p:leading-[2] md:prose-p:mb-8 [&_.twitter-tweet]:mx-auto [&_iframe]:mx-auto [&_iframe]:max-w-full"
             >
               <slot />
             </div>
 
             <!-- シェアボタンエリア -->
-            <div class="mt-8 border-t border-gray-200 py-4">
+            <div class="mt-8 border-t border-stone-200 py-4">
               <Share url={Astro.url.href} title={title} />
             </div>
 

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -59,7 +59,7 @@ const ogpStaticImage = cover
             </div>
 
             <div
-              class="prose prose-base mx-auto max-w-[40rem] text-gray-800 prose-p:leading-relaxed prose-p:mb-6 md:text-[1.0625rem] md:leading-[2] md:tracking-[0.015em] md:prose-p:leading-[2] md:prose-p:mb-8 [&_.twitter-tweet]:mx-auto [&_iframe]:mx-auto [&_iframe]:max-w-full"
+              class="prose mx-auto max-w-[40rem] text-stone-800 prose-p:leading-relaxed prose-p:mb-6 md:text-article md:leading-[2] md:tracking-[0.015em] md:prose-p:leading-[2] md:prose-p:mb-8 [&_.twitter-tweet]:mx-auto [&_iframe]:mx-auto [&_iframe]:max-w-full"
             >
               <slot />
             </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -11,9 +11,10 @@ interface Props {
   datePublished?: string
   twitterImage?: string
   markdownUrl?: string
+  bodyBackground?: string
 }
 
-const props = Astro.props
+const { bodyBackground = "bg-stone-50", ...props } = Astro.props
 ---
 
 <!doctype html>
@@ -21,7 +22,7 @@ const props = Astro.props
   <head>
     <BaseHead {...props} />
   </head>
-  <body class="flex min-h-screen flex-col bg-stone-50">
+  <body class={`flex min-h-screen flex-col ${bodyBackground}`}>
     <Header />
     <main class="grow">
       <div class="mx-auto mb-4 max-w-5xl">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -11,7 +11,7 @@ interface Props {
   datePublished?: string
   twitterImage?: string
   markdownUrl?: string
-  bodyBackground?: string
+  bodyBackground?: "bg-stone-50" | "bg-white"
 }
 
 const { bodyBackground = "bg-stone-50", ...props } = Astro.props

--- a/src/pages/page/[slug].astro
+++ b/src/pages/page/[slug].astro
@@ -27,7 +27,9 @@ const { Content } = await render(page)
 ---
 
 <Layout title={page.data.title}>
-  <div class="prose prose-sm mx-auto max-w-3xl md:prose-base">
+  <div
+    class="prose prose-sm mx-auto max-w-[40rem] text-stone-800 md:prose-base md:text-article md:leading-[2] md:tracking-[0.015em] md:prose-p:leading-[2] md:prose-p:mb-8"
+  >
     <Content
       components={{
         h2: MdxH2,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,7 +7,9 @@
     "Hiragino Kaku Gothic ProN", "Noto Sans JP", "Yu Gothic UI", Meiryo,
     sans-serif;
   --font-relics: "Times New Roman", "MS PGothic";
-  --font-ui: system-ui, -apple-system;
+
+  /* 記事本文の基準サイズ（デスクトップ17px相当）。BlogPost.astroとMdxH4で共有 */
+  --text-article: 1.0625rem;
 
   --color-accent: #9a3412;
   --color-primary: #b45309;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,7 +2,10 @@
 @plugin "@tailwindcss/typography";
 
 @theme {
-  --font-sans: sans-serif;
+  --font-sans:
+    system-ui, -apple-system, "Segoe UI", "Hiragino Sans",
+    "Hiragino Kaku Gothic ProN", "Noto Sans JP", "Yu Gothic UI", Meiryo,
+    sans-serif;
   --font-relics: "Times New Roman", "MS PGothic";
   --font-ui: system-ui, -apple-system;
 


### PR DESCRIPTION
## 概要

デスクトップの記事本文が読みづらい課題（幅774px・20.25px・行間1.625で約38字/行、装飾過多）に対し、「しずかなインターネット」「note」の実測値を根拠にミニマルな組版へ改修する。

| 項目 | 現行 | しずかなインターネット | note | 変更後 |
|---|---|---|---|---|
| 本文幅 | 774px | 604px | 620px | 640px |
| フォント | 20.25px | 17px | 20.25px | 17px相当(1.0625rem) |
| 行間 | 1.625 | 2.0 | 2.0 | 2.0 |
| 字数/行 | 38字 | 35字 | 31字 | 約37字 |

## 変更内容

- **本文組版**（BlogPost.astro）: 最大幅640px・17px・行間2.0・字間0.015em。md以上のみ適用でモバイルは現状維持
- **装飾ミニマル化**: strongマーカー下線廃止／h2左ボーダー・h3下ボーダー廃止（余白+サイズ差24/20/17pxで階層表現）／blockquoteのamber背景・italic廃止／リンクを本文色+常時グレー下線（hoverでprimary）に変更
- **白フラット化**: Layout.astroに`bodyBackground` prop追加、記事ページのみ背景白・カード影/角丸廃止。トップページは現状維持
- **カード控えめ化**: Amazonカードの3pxオレンジ枠→1px stone枠+文字ラベル（アフィリンク識別は維持）
- **フォント**: システムフォントスタックを明示定義（Webフォント追加なし、表示速度への影響なし）
- **周辺**: 記事h1をmd以上でtext-3xl化、StickyToc非activeリンクを淡色化

## 検証

- デスクトップ1440px: 行間2.00・約37.6字/行を実測確認。見出し階層・strong・リンク・blockquote・Amazonカード・テーブル・Tweet/YouTube埋込・StickyTocの表示を目視確認
- モバイル相当幅: 本文フォントサイズ・行間が現状値のまま（変更はmd以上のみ）
- トップページ: stone-50背景+カード表示の現状維持を確認
- `pnpm build` 成功（471ページ）、Prettier・Knipエラーなし

## 補足

寸法はrem基準のため、ブラウザのフォントサイズ設定に追従する（標準16px設定で17px/640px表示）。デザインプレビュー（新旧比較カード4枚）はClaude Designの「Design System」プロジェクトに同期済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8zsHbUffErwvVvrPoiFAs

## Merge Schedule

/schedule 2026-07-12T23:00:00.000+09:00

CI成功が条件（require_statuses_success: true）。cronは14時UTC台に起動しないため、実行は次回起動枠の22:00 UTC（7/13 07:00 JST）になる見込み。
