### PR TITLE
ci: merge-scheduleのタイムゾーンをAsia/Tokyoに変更

### DIFF
--- a/.github/workflows/merge-schedule.yml
+++ b/.github/workflows/merge-schedule.yml
@@ -8,8 +8,8 @@ on:
       - synchronize
   schedule:
     # https://crontab.guru/every-hour
-    # UTC
-    - cron: "*/30 0,3-4,10-12,22-23 * * *"
+    # cronはUTC固定（JSTでは 9, 12-13, 19-21, 23, 7-8 時台に相当）
+    - cron: "*/30 0,3-4,10-12,14,22-23 * * *"
 
 jobs:
   merge_schedule:
@@ -21,7 +21,9 @@ jobs:
           # rebase. Default is merge.
           merge_method: squash
           # Time zone to use. Default is UTC.
-          time_zone: "UTC"
+          # /schedule のオフセットなし日時はJSTとして解釈される
+          # （Z や +09:00 付きの明示指定はそのまま尊重される）
+          time_zone: "Asia/Tokyo"
           # Require all pull request statuses to be successful before
           # merging. Default is `false`.
           require_statuses_success: "true"


### PR DESCRIPTION
## 概要

merge-schedule-action の `time_zone` を `Asia/Tokyo` に変更し、`/schedule` をJSTの素の時刻で書けるようにする。あわせて cron に 14時UTC台（23時JST台）を追加する。

## 背景

PR #511 を 7/12 23:00 JST にスケジュールマージするにあたり、以下の2点が必要になった。

1. **タイムゾーン**: 現状 `UTC` のため、JSTで書いた時刻が9時間ずれる
2. **cron**: 現状 `0,3-4,10-12,22-23` UTC時台のみ起動のため、23:00 JST（= 14:00 UTC）にはアクション自体が実行されない

## 影響範囲

- 既存の依存更新ルーチン（automation/dependency-update.md）は `Z` 付きUTC明示指定（例: `/schedule 2026-04-27T22:00:00Z`）のため、タイムゾーン変更の影響を受けない
- cron実行はmaster上のワークフロー定義を使うため、**このPRは 7/12 より前にマージが必要**（PR #511 のスケジュール実行の前提）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8zsHbUffErwvVvrPoiFAs