### PR TITLE
docs+refactor: CLAUDE.md 見直しとディレクティブ定義の単一化

### DIFF
--- a/.claude/rules/knip.md
+++ b/.claude/rules/knip.md
@@ -5,18 +5,18 @@ paths:
 
 # knip.json の ignoreFiles / ignoreDependencies について
 
-意図的な除外設定であり、削除すると `pnpm lint:unused` が exit 1 になる。現在の全エントリ（ファイル8件・依存16件）が必要であることは、除外を外して knip を実行して確認済み。
+意図的な除外設定であり、削除すると `pnpm lint:unused` が exit 1 になる。現在の全エントリ（ファイル6件・依存16件）が必要であることは、除外を外して knip を実行して確認済み。
 
 `ignore` の4パターンについて Configuration hints が出るが、基準状態の exit code は 0。このヒントを解消しようとしなくてよい。
 
 ## ignoreFiles
 
-`src/components/mdx/` の8ファイル（`Amzn.astro`, `AmznServer.astro`, `LinkCard.astro`, `LinkCardServer.astro`, `SimpleLinkCard.astro`, `PositiveBox.astro`, `NegativeBox.astro`, `cardStyles.ts`）:
-自作 Vite プラグイン `src/plugins/mdx-auto-import.ts` が、`astro.config.ts` の `mdxAutoImport([...])` の指定に従って全 MDX へ import 文を注入する。knip はこのプラグインを解釈できず、かつ `src/content/**` が ignore 対象のため、除外を外すと8件すべてが Unused files として報告される。
-
-`PositiveBox.astro` / `NegativeBox.astro` はさらに間接的で、記事は `:::positive` / `:::negative` のディレクティブ記法で書き、`src/plugins/satteri-directive-components.ts` がコンポーネント名へ変換する。記事中にコンポーネント名の文字列すら現れない。
+`src/components/mdx/` の6ファイル（`Amzn.astro`, `AmznServer.astro`, `LinkCard.astro`, `LinkCardServer.astro`, `SimpleLinkCard.astro`, `cardStyles.ts`）:
+自作 Vite プラグイン `src/plugins/mdx-auto-import.ts` が、`astro.config.ts` の `mdxAutoImport([...])` の指定に従って全 MDX へ import 文を注入する。knip はこのプラグインを解釈できず、かつ `src/content/**` が ignore 対象のため、除外を外すと6件すべてが Unused files として報告される。
 
 自動注入の対象を追加したときは、そのコンポーネントと専用の依存ファイルをここにも追加する。
+
+`PositiveBox.astro` / `NegativeBox.astro` は自動注入をやめ、`src/pages/post/[...slug].astro` と `src/pages/page/[slug].astro` の `<Content components={{...}}>` から渡す形にしたため除外不要になった。同様に import で辿れる形にできるコンポーネントは `ignoreFiles` に足さない。
 
 ## ignoreDependencies
 

--- a/.claude/rules/knip.md
+++ b/.claude/rules/knip.md
@@ -5,23 +5,24 @@ paths:
 
 # knip.json の ignoreFiles / ignoreDependencies について
 
-意図的に多数の除外設定が入っている。誤って削除しないこと。
+意図的な除外設定であり、削除すると `pnpm lint:unused` が exit 1 になる。現在の全エントリ（ファイル8件・依存16件）が必要であることは、除外を外して knip を実行して確認済み。
+
+`ignore` の4パターンについて Configuration hints が出るが、基準状態の exit code は 0。このヒントを解消しようとしなくてよい。
 
 ## ignoreFiles
 
-- **MDXコンポーネント群**（`Amzn.astro`, `LinkCard.astro`, `SimpleLinkCard.astro`, `positive.tsx`, `negative.tsx` およびそれらが依存するファイル）:
-  `astro-auto-import` で全MDXファイルにビルド時注入される。knipにはastro-auto-importプラグインがなく、かつ `src/content/**` がignore対象のためknipが使用を検出できない。
+`src/components/mdx/` の8ファイル（`Amzn.astro`, `AmznServer.astro`, `LinkCard.astro`, `LinkCardServer.astro`, `SimpleLinkCard.astro`, `PositiveBox.astro`, `NegativeBox.astro`, `cardStyles.ts`）:
+自作 Vite プラグイン `src/plugins/mdx-auto-import.ts` が、`astro.config.ts` の `mdxAutoImport([...])` の指定に従って全 MDX へ import 文を注入する。knip はこのプラグインを解釈できず、かつ `src/content/**` が ignore 対象のため、除外を外すと8件すべてが Unused files として報告される。
 
-- **`cfImageService.ts`**:
-  `astro.config.ts` 内で文字列として参照されるため静的解析で検出不可。
+自動注入の対象を追加したときは、そのコンポーネントと専用の依存ファイルをここにも追加する。
 
 ## ignoreDependencies
 
+- **`cloudflare`**:
+  `import { env } from "cloudflare:workers"` を knip が `cloudflare` パッケージへの参照と解釈する。実体は Workers ランタイム組み込みで package.json には存在しない。除外を外すと Unlisted dependencies として5ファイル分（`src/pages/post/[...slug].md.ts`, `src/server/services/ogImage.tsx`, `test/adapters/` 2件, `test/services/paapi.test.ts`）報告される
+
 - **`tailwindcss`, `@tailwindcss/typography`**:
-  Tailwind v4 では `src/styles/global.css` の `@import "tailwindcss"` と `@plugin "@tailwindcss/typography"` で使用される。CSS ファイル内参照のため knip が検出できない。
+  Tailwind v4 では `src/styles/global.css` の `@import "tailwindcss"` と `@plugin "@tailwindcss/typography"` で参照する。CSS ファイル内の参照を knip が追跡できない
 
-- **`textlint-*`**:
-  VS Code拡張（vscode-textlint）が直接参照する。scriptsやCIには登場しないがアンインストール不可。
-
-- **`@iconify-json/mdi`, `swr`, `react-icons` 等**:
-  astro-iconやignoreFiles対象コンポーネントから使用されているが、knipのトレースが届かない。
+- **`textlint` と `textlint-rule-*` / `@textlint-ja/*`（計13パッケージ）**:
+  `.textlintrc` からのみ参照される。npm script も CI ジョブも持たず（実行は VS Code 拡張経由）knip からは未使用に見えるが、アンインストールすると textlint が動かなくなる

--- a/.claude/rules/knip.md
+++ b/.claude/rules/knip.md
@@ -14,6 +14,8 @@ paths:
 `src/components/mdx/` の8ファイル（`Amzn.astro`, `AmznServer.astro`, `LinkCard.astro`, `LinkCardServer.astro`, `SimpleLinkCard.astro`, `PositiveBox.astro`, `NegativeBox.astro`, `cardStyles.ts`）:
 自作 Vite プラグイン `src/plugins/mdx-auto-import.ts` が、`astro.config.ts` の `mdxAutoImport([...])` の指定に従って全 MDX へ import 文を注入する。knip はこのプラグインを解釈できず、かつ `src/content/**` が ignore 対象のため、除外を外すと8件すべてが Unused files として報告される。
 
+`PositiveBox.astro` / `NegativeBox.astro` はさらに間接的で、記事は `:::positive` / `:::negative` のディレクティブ記法で書き、`src/plugins/satteri-directive-components.ts` がコンポーネント名へ変換する。記事中にコンポーネント名の文字列すら現れない。
+
 自動注入の対象を追加したときは、そのコンポーネントと専用の依存ファイルをここにも追加する。
 
 ## ignoreDependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,80 +1,47 @@
 # 幻想サイクル（Genso Cycle）ブログ
 
-## 技術スタック
+Astro + Cloudflare Workers（Static Assets + KV）で動く自転車ブログ。記事は `src/content/post/<年>/<月>/*.mdx`。
+フレームワーク・依存のバージョンは `package.json`、Workers 側の構成は `wrangler.jsonc` が正。
 
-- **フレームワーク**: Astro v6（Server Islands）
-- **UIライブラリ**: React（SocialShare, StickyToc のみ）
-- **スタイリング**: Tailwind CSS
-- **検索機能**: Pagefind
-- **ホスティング**: Cloudflare Workers + Static Assets
-- **サーバーサイド**: Cloudflare Workers
-- **画像処理**: Cloudflare Image Service
-- **データベース**: Cloudflare KV（OGP, PAAPIデータキャッシュ用）
-- **パッケージマネージャー**: pnpm
+React は `src/components/jsx/share.tsx` と `StickyToc.tsx` の 2 つだけ。他は Astro コンポーネントで実装する。
 
-Server Islands（`server:defer`）で `LinkCard.astro` / `Amzn.astro` がサーバーサイドで KV と外部 API にアクセス。PAAPIデータは KV に24時間 TTL でキャッシュ。
+## コマンド
 
-## 環境変数
+- `pnpm dev` — workerd（Miniflare）上で起動。KV バインディングもローカルシミュレーションされる
+- `pnpm dev:cf` — `pnpm build` 後に `dist/server/wrangler.json` で serve。本番ビルドの確認用
+- `pnpm test:light` — シークレット不要。Claude Code Web サンドボックスでは常にこちらを使う
+- `pnpm test` — `test/services` を含み実 Amazon API を叩く。`PARTNER_TAG` / `CREATORS_CREDENTIAL_*` が必要で CI（lint-test.yml）専用
+- `pnpm lint:unused` — knip。`git push` 前に必須
 
-必要なシークレットは `wrangler.jsonc` の `secrets.required` が正規定義。ローカル開発は `.dev.vars` に同名キーを設定する。
+Prettier は Edit / Write の PostToolUse フック（`.claude/settings.json`）で自動実行されるので手動実行は不要。`pnpm lint` は Prettier のみで、textlint は npm script を持たず VS Code 拡張から実行される。記事 MDX（`src/content/post`）は `.prettierignore` 対象で整形されない。
 
-## デプロイフロー
+## 実装の注意点
 
-Cloudflare Workers + Static AssetsでのGitHubリポジトリ連携でビルド・デプロイ。ローカルからデプロイは行わない。
+### MDX のコンポーネント自動注入
 
-## 開発ワークフロー
+`src/plugins/mdx-auto-import.ts` が LinkCard / Amzn / SimpleLinkCard / PositiveBox / NegativeBox を全 MDX に注入する。MDX 側に import を書いてはいけない。自動注入対象を増やすときは `astro.config.ts` の `mdxAutoImport([...])` と `knip.json` の `ignoreFiles` を両方更新する。
 
-- 通常開発： `pnpm dev` 開発サーバーが workerd（Miniflare）上で動作。HMR付きで KV バインディングもローカルシミュレーション可能
-- 本番ビルド確認： `pnpm dev:cf` `pnpm build` 後に `wrangler dev --config dist/server/wrangler.json` で serve
-- 本番ビルド： `pnpm build`
+MDX から `server:defer` 付きの Astro コンポーネントを直接使えないため、`LinkCard.astro` / `Amzn.astro` はラッパーで、KV と外部 API にアクセスする実体は `LinkCardServer.astro` / `AmznServer.astro`。PAAPI データは KV に 24 時間 TTL でキャッシュ。
 
-### コード管理
+### Cloudflare Workers
 
-- Linter: Prettierを `pnpm lint:fix` で修正。自動修正できないエラーは `pnpm lint` で表示して手動で変更
-- Cleanup(MUST): TypeScriptクリーンアップを `git push` 前にKnipを `pnpm lint:unused` で実行
+- 環境変数は `import { env } from "cloudflare:workers"`。`Astro.locals.runtime.env` は廃止済みで使わない
+- ローカル開発のシークレットは `.dev.vars` に置く。必要なキーの正規定義は `wrangler.jsonc` の `secrets.required`
+- Image Service は `WORKERS_CI_BRANCH === "master"` のときだけ有効（プレビュードメインでは `cdn-cgi/image` が 404 になるため）
+- vitest はカスタム Worker エントリを読み込めないため、テストは `main` を持たない `wrangler.test.jsonc` を参照する。`wrangler.jsonc` のバインディングを変えたら両方同期する
 
-### 設定ファイル
+### AIエージェント向け Markdown 配信
 
-- **`wrangler.jsonc`**: Workers設定（KVバインディング、静的アセット設定等）
-- **`astro.config.ts`**: Astro設定（出力ディレクトリ：`./dist/`）
+`src/worker.ts` が `cf.verifiedBotCategory` / UA / `Accept: text/markdown` で AI エージェントを判定し、`/post/<slug>/` を SSR エンドポイント `/post/<slug>.md`（`src/pages/post/[...slug].md.ts`）へ内部リライトする。`wrangler.jsonc` の `assets.run_worker_first: ["/post/*"]` が前提。
 
-## 特記事項
+### タグと URL
 
-- Cloudflare Image Service 本番のみ有効（maxWidth: 800px）
-- **タグ管理**: 18個の正規化タグ。主要: REVIEW, CX, ROAD, RACEREPORT, MTB, TIPS, GRAVEL, Workout, Zwift
-  - レガシーURL（`/category/*`, `/categories/*`, `/search/label/*`）は `/tag/*` 構造にリダイレクト済み
+`src/content.config.ts` の tags は `z.string().array().min(1)` で enum 検証がない。`src/pages/tag/[tag]/[page].astro` が全記事からタグを集めてページを生成するため、表記を間違えると孤立した `/tag/*` ページが静的生成される。タグは既存記事の frontmatter にある表記から選び、新しいタグを勝手に追加しない。
 
-## 実装注記
+レガシー URL（`/category/*`, `/categories/*`, `/search/label/*`、旧 Blogger の `.html`）のリダイレクトは `public/_redirects`。
 
-### Cloudflare Workers 環境変数
+## デプロイと自動化
 
-- `Astro.locals.runtime.env` は廃止 → `import { env } from 'cloudflare:workers'` を使う
-- MDXのIslandコンポーネントにおいて、MDXから直接 `server:defer` ディレクティブを持つAstroコンポーネントを使用できないためラッパーパターンを利用
-
-### AIエージェント向けMarkdown配信
-
-- カスタムWorkerエントリ `src/worker.ts`（`wrangler.jsonc` の `main`）が `cf.verifiedBotCategory` / UA / `Accept: text/markdown` でAIエージェントを判定し、`/post/<slug>/` を SSRエンドポイント `/post/<slug>.md`（`src/pages/post/[...slug].md.ts`）へ内部リライトする。`assets.run_worker_first: ["/post/*"]` が前提
-- vitest はカスタムWorkerエントリを読み込めないため、テストは `main` を持たない `wrangler.test.jsonc` を参照する。`wrangler.jsonc` のバインディング変更時は両ファイルを同期すること
-
-## テストコマンド
-
-| コマンド          | 対象                           | 実行場所                  | シークレット                              |
-| ----------------- | ------------------------------ | ------------------------- | ----------------------------------------- |
-| `pnpm test:light` | unit / domain / adapters       | ローカル・Claude Code Web | 不要                                      |
-| `pnpm test`       | 全テスト（実 Amazon API 含む） | CI のみ                   | PARTNER*TAG / CREATORS_CREDENTIAL*\* 必要 |
-
-Claude Code Web サンドボックスでは常に `pnpm test:light` を使用する。`pnpm test` は CI（lint-test.yml）に委任。
-
-## 依存更新ルーチン
-
-`automation/dependency-update.md` に定義した手順を Claude Code Web の scheduled agent（週次 月曜 09:00 JST）が実行。`.claude/` 配下に置くと許可ダイアログでルーチンが停止するため、自動化関連ファイルはプロジェクトルートの `automation/` に配置する。
-
-- **単一PR方針**: 全安全な更新を 1 ブランチ・1 PR（`deps/update-YYYYMMDD`）にまとめる。patch/minor はフェーズ1で一括、major は調査後フェーズ2で個別適用
-- **自動マージ**: 既存 `gr2m/merge-schedule-action` を利用。major なし → 次の月曜 22:00 UTC 自動マージ、major あり → 手動マージ
-- **待機中の更新**: `automation/pending-updates.json` に記録し、次回セッションで参照
-- **engine 連動ピン**: `automation/engine-pinned-packages.json` で宣言したパッケージ（現在 `@types/node` → `maxMajor: 24`）は major PR を作らず pending に積む。Node.js を 25 以上に上げる際はこのファイルの `maxMajor` を手動更新する
-
-## Project Level MCP Server
-
-- `cloudflare-documentation`: Workers/Wrangler ナレッジ
-- `astro-docs`: Astro フレームワーク仕様
+- デプロイは GitHub リポジトリ連携で Cloudflare が実行。ローカルから `wrangler deploy` はしない
+- 週次の依存更新ルーチンは `automation/dependency-update.md`。`.claude/` 配下に置くと許可ダイアログでルーチンが停止するため `automation/` に置いている
+- `knip.json` の除外設定を触る際の判断材料は `.claude/rules/knip.md`（`paths` 指定で自動読み込み）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,9 @@ Prettier は Edit / Write の PostToolUse フック（`.claude/settings.json`）
 記事側に import は書かない。記法は 2 系統ある。
 
 - JSX 記法（`<LinkCard>` `<Amzn>` `<SimpleLinkCard>`）: `src/plugins/mdx-auto-import.ts` が全 MDX へ import 文を注入する。対象一覧は `astro.config.ts` の `mdxAutoImport([...])` が正。増やすときは `knip.json` の `ignoreFiles` も更新する
-- コンテナディレクティブ記法（`:::positive` / `:::negative`）: satteri の `features.directive` が解析し、`src/plugins/satteri-directive-components.ts` の `DIRECTIVE_TO_COMPONENT` がディレクティブ名をコンポーネント名へ変換する。対応表はこのファイルが正で、装飾は変換先の `.astro` が持つ
+- コンテナディレクティブ記法（`:::positive` / `:::negative`）: 定義は `src/lib/directives.ts` の `DIRECTIVES` が単一の正で、コンポーネント名と Markdown 配信時の引用プレフィックスを持つ。satteri の `features.directive` が解析し、`src/plugins/satteri-directive-components.ts` が `DIRECTIVES` を引いて JSX ノードへ変換、`src/pages/post/[...slug].astro` と `src/pages/page/[slug].astro` の `<Content components={{...}}>` がコンポーネントを解決する
 
-記事本文で `<PositiveBox>` / `<NegativeBox>` を JSX として書くことはしない（既存記事の使用箇所はすべてディレクティブ記法）。
+記事本文で `<PositiveBox>` / `<NegativeBox>` を JSX として書くことはしない。ディレクティブを追加するときは `DIRECTIVES` へ1エントリ足し、レンダリング用の `.astro` を作って両方の `components` マップへ渡す。マップへの追加を忘れるとビルドが `Expected component ... to be defined` で落ちる。`test/unit/contentLint.test.ts` が記事の `:::` 名を `DIRECTIVES` と突き合わせ、`test/domain/postToMarkdown.test.ts` が全エントリの Markdown 変換を検証する。
 
 MDX から `server:defer` 付きの Astro コンポーネントを直接使えないため、`LinkCard.astro` / `Amzn.astro` はラッパーで、KV と外部 API にアクセスする実体は `LinkCardServer.astro` / `AmznServer.astro`。PAAPI データは KV に 24 時間 TTL でキャッシュ。
 
@@ -38,6 +38,8 @@ MDX から `server:defer` 付きの Astro コンポーネントを直接使え�
 ### AIエージェント向け Markdown 配信
 
 `src/worker.ts` が `cf.verifiedBotCategory` / UA / `Accept: text/markdown` で AI エージェントを判定し、`/post/<slug>/` を SSR エンドポイント `/post/<slug>.md`（`src/pages/post/[...slug].md.ts`）へ内部リライトする。`wrangler.jsonc` の `assets.run_worker_first: ["/post/*"]` が前提。
+
+MDX → Markdown の変換は `src/lib/postToMarkdown.ts`。レンダリング経路とは別実装なので、記事の拡張記法を増やしたらここも追随させる。
 
 ### タグと URL
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,14 @@ Prettier は Edit / Write の PostToolUse フック（`.claude/settings.json`）
 
 ## 実装の注意点
 
-### MDX のコンポーネント自動注入
+### 記事 MDX の拡張記法
 
-`src/plugins/mdx-auto-import.ts` が LinkCard / Amzn / SimpleLinkCard / PositiveBox / NegativeBox を全 MDX に注入する。MDX 側に import を書いてはいけない。自動注入対象を増やすときは `astro.config.ts` の `mdxAutoImport([...])` と `knip.json` の `ignoreFiles` を両方更新する。
+記事側に import は書かない。記法は 2 系統ある。
+
+- JSX 記法（`<LinkCard>` `<Amzn>` `<SimpleLinkCard>`）: `src/plugins/mdx-auto-import.ts` が全 MDX へ import 文を注入する。対象一覧は `astro.config.ts` の `mdxAutoImport([...])` が正。増やすときは `knip.json` の `ignoreFiles` も更新する
+- コンテナディレクティブ記法（`:::positive` / `:::negative`）: satteri の `features.directive` が解析し、`src/plugins/satteri-directive-components.ts` の `DIRECTIVE_TO_COMPONENT` がディレクティブ名をコンポーネント名へ変換する。対応表はこのファイルが正で、装飾は変換先の `.astro` が持つ
+
+記事本文で `<PositiveBox>` / `<NegativeBox>` を JSX として書くことはしない（既存記事の使用箇所はすべてディレクティブ記法）。
 
 MDX から `server:defer` 付きの Astro コンポーネントを直接使えないため、`LinkCard.astro` / `Amzn.astro` はラッパーで、KV と外部 API にアクセスする実体は `LinkCardServer.astro` / `AmznServer.astro`。PAAPI データは KV に 24 時間 TTL でキャッシュ。
 

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -35,9 +35,7 @@ export default defineConfig({
       mdxAutoImport([
         "./src/components/mdx/LinkCard.astro",
         "./src/components/mdx/Amzn.astro",
-        "./src/components/mdx/SimpleLinkCard.astro",
-        "./src/components/mdx/PositiveBox.astro",
-        "./src/components/mdx/NegativeBox.astro"
+        "./src/components/mdx/SimpleLinkCard.astro"
       ]),
       tailwindcss()
     ]

--- a/knip.json
+++ b/knip.json
@@ -13,9 +13,7 @@
     "src/components/mdx/cardStyles.ts",
     "src/components/mdx/LinkCard.astro",
     "src/components/mdx/LinkCardServer.astro",
-    "src/components/mdx/SimpleLinkCard.astro",
-    "src/components/mdx/PositiveBox.astro",
-    "src/components/mdx/NegativeBox.astro"
+    "src/components/mdx/SimpleLinkCard.astro"
   ],
   "ignoreDependencies": [
     "tailwindcss",

--- a/src/lib/directives.ts
+++ b/src/lib/directives.ts
@@ -1,0 +1,14 @@
+/**
+ * 記事 MDX のコンテナディレクティブ記法（:::positive など）の定義。
+ * レンダリング経路（satteri プラグイン）と Markdown 配信経路（postToMarkdown）が
+ * このファイルを参照する。
+ */
+export const DIRECTIVES = {
+  positive: { component: "PositiveBox", markdownPrefix: "> 😊" },
+  negative: { component: "NegativeBox", markdownPrefix: "> 😞" }
+} as const
+
+export type DirectiveName = keyof typeof DIRECTIVES
+
+export const isDirectiveName = (name: string): name is DirectiveName =>
+  name in DIRECTIVES

--- a/src/lib/postToMarkdown.ts
+++ b/src/lib/postToMarkdown.ts
@@ -1,3 +1,11 @@
+import { DIRECTIVES, type DirectiveName } from "./directives"
+
+// :::positive ... ::: の1ブロック。ディレクティブ名はレジストリから生成する
+const directiveFencePattern = new RegExp(
+  `^:::(${Object.keys(DIRECTIVES).join("|")})[ \\t]*\\r?\\n([\\s\\S]*?)\\r?\\n:::[ \\t]*$`,
+  "gm"
+)
+
 interface PostToMarkdownInput {
   slug: string
   title: string
@@ -53,29 +61,15 @@ const transformSegment = (segment: string, partnerTag: string): string => {
     return `[${text}](${href})`
   })
 
-  // 6. <PositiveBox>内容</PositiveBox> → 引用ブロック（> 😊）
+  // 6. コンテナディレクティブ（:::positive / :::negative）→ 絵文字付き引用ブロック
   segment = segment.replace(
-    /<PositiveBox>([\s\S]*?)<\/PositiveBox>/g,
-    (_, content) => {
-      const trimmed = content.trim()
-      const lines = trimmed.split("\n")
+    directiveFencePattern,
+    (_, name: string, content: string) => {
+      const lines = content.trim().split("\n")
       const quoted = lines.map((line) =>
         line.trim() === "" ? ">" : `> ${line}`
       )
-      return `> 😊\n${quoted.join("\n")}`
-    }
-  )
-
-  // <NegativeBox>内容</NegativeBox> → 引用ブロック（> 😞）
-  segment = segment.replace(
-    /<NegativeBox>([\s\S]*?)<\/NegativeBox>/g,
-    (_, content) => {
-      const trimmed = content.trim()
-      const lines = trimmed.split("\n")
-      const quoted = lines.map((line) =>
-        line.trim() === "" ? ">" : `> ${line}`
-      )
-      return `> 😞\n${quoted.join("\n")}`
+      return `${DIRECTIVES[name as DirectiveName].markdownPrefix}\n${quoted.join("\n")}`
     }
   )
 

--- a/src/pages/page/[slug].astro
+++ b/src/pages/page/[slug].astro
@@ -20,6 +20,8 @@ import MdxH3 from "@components/mdx/MdxH3.astro"
 import MdxH4 from "@components/mdx/MdxH4.astro"
 import MdxStrong from "@components/mdx/MdxStrong.astro"
 import MdxTable from "@components/mdx/MdxTable.astro"
+import NegativeBox from "@components/mdx/NegativeBox.astro"
+import PositiveBox from "@components/mdx/PositiveBox.astro"
 
 type Props = CollectionEntry<"singlePage">
 const page = Astro.props
@@ -38,7 +40,9 @@ const { Content } = await render(page)
         blockquote: MdxBlockQuote,
         a: MdxA,
         table: MdxTable,
-        strong: MdxStrong
+        strong: MdxStrong,
+        PositiveBox,
+        NegativeBox
       }}
     />
   </div>

--- a/src/pages/post/[...slug].astro
+++ b/src/pages/post/[...slug].astro
@@ -9,6 +9,8 @@ import MdxH4 from "@components/mdx/MdxH4.astro"
 import MdxPicture from "@components/mdx/MdxPicture.astro"
 import MdxStrong from "@components/mdx/MdxStrong.astro"
 import MdxTable from "@components/mdx/MdxTable.astro"
+import NegativeBox from "@components/mdx/NegativeBox.astro"
+import PositiveBox from "@components/mdx/PositiveBox.astro"
 import BlogPost from "@layouts/BlogPost.astro"
 import { extractDescription } from "@lib/extractDescription"
 import { slugFromId } from "@lib/postSlug"
@@ -47,7 +49,9 @@ const markdownUrl = `${SITE_URL}post/${slugFromId(post.id)}.md`
       a: MdxA,
       table: MdxTable,
       strong: MdxStrong,
-      img: MdxPicture
+      img: MdxPicture,
+      PositiveBox,
+      NegativeBox
     }}
   />
 </BlogPost>

--- a/src/plugins/satteri-directive-components.ts
+++ b/src/plugins/satteri-directive-components.ts
@@ -1,21 +1,17 @@
 import { defineMdastPlugin } from "satteri"
 import type { MdxJsxFlowElement } from "satteri"
 
-const DIRECTIVE_TO_COMPONENT: Record<string, string> = {
-  positive: "PositiveBox",
-  negative: "NegativeBox"
-}
+import { DIRECTIVES, isDirectiveName } from "../lib/directives"
 
 export function directiveComponentPlugin() {
   return defineMdastPlugin({
     name: "directive-components",
     containerDirective(node) {
-      const componentName = DIRECTIVE_TO_COMPONENT[node.name]
-      if (!componentName) return
+      if (!isDirectiveName(node.name)) return
 
       return {
         type: "mdxJsxFlowElement",
-        name: componentName,
+        name: DIRECTIVES[node.name].component,
         attributes: [],
         children: node.children
       } satisfies MdxJsxFlowElement

--- a/test/domain/postToMarkdown.test.ts
+++ b/test/domain/postToMarkdown.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "vitest"
+import { DIRECTIVES, type DirectiveName } from "../../src/lib/directives"
 import { postToMarkdown } from "../../src/lib/postToMarkdown"
 
 const BASE_INPUT = {
@@ -132,35 +133,50 @@ test("<SimpleLinkCard url='...' /> title なし → [url](url)", () => {
   expect(result).toContain("[https://example.com/](https://example.com/)")
 })
 
-// === ルール6: PositiveBox / NegativeBox ===
+// === ルール6: コンテナディレクティブ ===
 
-test("<PositiveBox> が > 😊 引用ブロックに変換される", () => {
-  const body = `<PositiveBox>
-良い点です
-</PositiveBox>`
-  const result = postToMarkdown({ ...BASE_INPUT, body })
-  expect(result).toContain("> 😊")
-  expect(result).toContain("> 良い点です")
-})
+const directiveNames = Object.keys(DIRECTIVES) as DirectiveName[]
 
-test("<PositiveBox> リスト入り", () => {
-  const body = `<PositiveBox>
+test.each(directiveNames)(
+  ":::%s が定義どおりの引用ブロックに変換され ::: が残らない",
+  (name) => {
+    const body = `:::${name}\n本文です\n:::`
+    const result = postToMarkdown({ ...BASE_INPUT, body })
+    expect(result).toContain(DIRECTIVES[name].markdownPrefix)
+    expect(result).toContain("> 本文です")
+    expect(result).not.toContain(":::")
+  }
+)
+
+test(":::positive リスト入り", () => {
+  const body = `:::positive
 - 軽い
 - 速い
-</PositiveBox>`
+:::`
   const result = postToMarkdown({ ...BASE_INPUT, body })
   expect(result).toContain("> 😊")
   expect(result).toContain("> - 軽い")
   expect(result).toContain("> - 速い")
 })
 
-test("<NegativeBox> が > 😞 引用ブロックに変換される", () => {
-  const body = `<NegativeBox>
-悪い点です
-</NegativeBox>`
+test("連続する2ブロックが個別に変換される", () => {
+  const body = `:::positive
+良い点
+:::
+
+:::negative
+悪い点
+:::`
   const result = postToMarkdown({ ...BASE_INPUT, body })
-  expect(result).toContain("> 😞")
-  expect(result).toContain("> 悪い点です")
+  expect(result).toContain("> 😊\n> 良い点")
+  expect(result).toContain("> 😞\n> 悪い点")
+  expect(result).not.toContain(":::")
+})
+
+test("未定義のディレクティブ名は変換されない", () => {
+  const body = ":::warning\n注意\n:::"
+  const result = postToMarkdown({ ...BASE_INPUT, body })
+  expect(result).toContain(":::warning")
 })
 
 // === ルール7: 相対パス画像 ===
@@ -217,6 +233,13 @@ test("コードフェンス内の <Amzn /> は変換されない", () => {
   const result = postToMarkdown({ ...BASE_INPUT, body })
   expect(result).toContain('<Amzn asin="B0044BG93S" />')
   expect(result).not.toContain("Amazonで見る")
+})
+
+test("コードフェンス内の :::positive は変換されない", () => {
+  const body = "```\n:::positive\n良い点\n:::\n```"
+  const result = postToMarkdown({ ...BASE_INPUT, body })
+  expect(result).toContain(":::positive")
+  expect(result).not.toContain("> 😊")
 })
 
 test("コードフェンス内の相対パス画像は除去されない", () => {

--- a/test/domain/postToMarkdown.test.ts
+++ b/test/domain/postToMarkdown.test.ts
@@ -173,6 +173,13 @@ test("連続する2ブロックが個別に変換される", () => {
   expect(result).not.toContain(":::")
 })
 
+test("CRLF改行のディレクティブも変換される", () => {
+  const body = ":::positive\r\n本文です\r\n:::\r\n"
+  const result = postToMarkdown({ ...BASE_INPUT, body })
+  expect(result).toContain("> 😊")
+  expect(result).not.toContain(":::")
+})
+
 test("未定義のディレクティブ名は変換されない", () => {
   const body = ":::warning\n注意\n:::"
   const result = postToMarkdown({ ...BASE_INPUT, body })

--- a/test/unit/contentLint.test.ts
+++ b/test/unit/contentLint.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "vitest"
+import { DIRECTIVES } from "../../src/lib/directives"
 
 // ビルド時(Vite)に全MDXソースを取り込む（workerd内ではfsを使えないため）
 const mdxSources = import.meta.glob("../../src/content/post/**/*.mdx", {
@@ -6,6 +7,16 @@ const mdxSources = import.meta.glob("../../src/content/post/**/*.mdx", {
   import: "default",
   eager: true
 }) as Record<string, string>
+
+// ディレクティブは post / singlePage 双方のレンダリング経路で解決されるため両方を対象にする
+const allMdxSources = {
+  ...mdxSources,
+  ...(import.meta.glob("../../src/content/singlePage/**/*.mdx", {
+    query: "?raw",
+    import: "default",
+    eager: true
+  }) as Record<string, string>)
+}
 
 test("MDXコンテンツを1件以上読み込めている", () => {
   expect(Object.keys(mdxSources).length).toBeGreaterThan(0)
@@ -15,5 +26,25 @@ test("LinkCardのprop誤記（小文字linkurl=）がMDXコンテンツに存在
   const offenders = Object.entries(mdxSources)
     .filter(([, source]) => /\blinkurl=/.test(source))
     .map(([path]) => path)
+  expect(offenders).toEqual([])
+})
+
+test("MDXで使われているコンテナディレクティブが全て DIRECTIVES に定義されている", () => {
+  const offenders = Object.entries(allMdxSources).flatMap(([path, source]) =>
+    [...source.matchAll(/^:::([a-z][a-z0-9-]*)/gm)]
+      .map((match) => match[1])
+      .filter((name) => !(name in DIRECTIVES))
+      .map((name) => `${path}: :::${name}`)
+  )
+  expect(offenders).toEqual([])
+})
+
+test("PositiveBox / NegativeBox がMDXでJSX記法として書かれていない", () => {
+  const componentNames = Object.values(DIRECTIVES).map((d) => d.component)
+  const offenders = Object.entries(allMdxSources).flatMap(([path, source]) =>
+    componentNames
+      .filter((name) => new RegExp(`<${name}[\\s>]`).test(source))
+      .map((name) => `${path}: <${name}>`)
+  )
   expect(offenders).toEqual([])
 })


### PR DESCRIPTION
## 変更内容

### 1. CLAUDE.md / knip ルールの見直し（`ceb8a878`, `48e47289`）

- 記述の重複と `package.json` / `wrangler.jsonc` から読み取れる事実を削り、実装の落とし穴に絞る
- `astro-auto-import` → 自作 `mdxAutoImport`、`positive.tsx`/`negative.tsx` → `PositiveBox.astro`/`NegativeBox.astro` など、実装と乖離していた記述を修正
- タグは enum 検証がないため誤記が孤立ページを生む点を追記

### 2. ディレクティブ定義の単一化と `.md` 出力の不具合修正（`a5700ea1`）

レンダリング経路と AI エージェント向け Markdown 配信経路がそれぞれ独立にディレクティブの対応表を持っていたため、JSX 記法（`<PositiveBox>`）からディレクティブ記法（`:::positive`）へ移行した際に後者が追随せず、`/post/<slug>.md` にリテラルの `:::` が漏れていた（30記事・65ブロック）。

- `src/lib/directives.ts` の `DIRECTIVES` を単一の正とし、satteri プラグインと `postToMarkdown` の両方が参照する
- `PositiveBox` / `NegativeBox` を `mdxAutoImport` の自動注入から外し、`post/[...slug].astro` と `page/[slug].astro` の `components` マップから渡す。解決漏れはビルドエラーになる
- `knip.json` の `ignoreFiles` が8件→6件

## 検証

| 項目 | 結果 |
| --- | --- |
| `pnpm test:light` | 98 passed（9ファイル） |
| `pnpm build` | exit 0 |
| `pnpm lint` / `pnpm lint:unused` | どちらも exit 0 |
| `.md` 出力 | ディレクティブ使用30記事すべてで `:::` 残存0件・絵文字引用ブロック生成を確認 |
| ネガティブコントロール | `components` マップから1件外すと build exit 1（`Expected component \`PositiveBox\` to be defined`） |
| レンダリング HTML | `dist/client/post/2022/04/agilest_tlr/index.html` に `border-info` / `border-error` と絵文字 SVG 各1件 |

## 乖離防止の仕組み

- `test/unit/contentLint.test.ts`: 記事（post / singlePage 両方）の `:::<名前>` が `DIRECTIVES` に定義されているかを検証。`:::warning` のような未定義名の混入を検出する
- `test/domain/postToMarkdown.test.ts`: `DIRECTIVES` を `test.each` で回し、全エントリで `:::` が残らないことを検証。コードフェンス内が変換されないことも検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rfcwMxfnKDoG4Us8XcDgW
