### PR TITLE
fix: #521 レビュー指摘の反映（satteri の記法を禁止せず postToMarkdown で受け付ける）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Prettier は Edit / Write の PostToolUse フック（`.claude/settings.json`）
 
 記事本文で `<PositiveBox>` / `<NegativeBox>` を JSX として書くことはしない。ディレクティブを追加するときは `DIRECTIVES` へ1エントリ足し、レンダリング用の `.astro` を作って両方の `components` マップへ渡す。マップへの追加を忘れるとビルドが `Expected component ... to be defined` で落ちる。`test/unit/contentLint.test.ts` が記事の `:::` 名を `DIRECTIVES` と突き合わせ、`test/domain/postToMarkdown.test.ts` が全エントリの Markdown 変換を検証する。
 
-記事に書けるのは行頭・コロン3個・名前のみの正規形（`:::positive`）だけ。satteri は `::::positive`・字下げ・`:::positive{.tight}`・`:::positive[label]` も解釈するが `postToMarkdown` は変換しないため、正規形以外は `/post/<slug>.md` に `:::` が露出する。非正規形は `test/unit/contentLint.test.ts` が検出して失敗する。
+記事に書けるのは開始行 `:::positive`・終了行 `:::` の正規形（どちらも行頭・コロン3個）だけ。satteri は `::::positive`・字下げ・`:::positive{.tight}`・`:::positive[label]`・`::::` での閉じも解釈するが `postToMarkdown` は変換しないため、正規形以外は `/post/<slug>.md` に `:::` が露出する。非正規形は `test/unit/contentLint.test.ts` が開始行・終了行の両方で検出して失敗する。
 
 MDX から `server:defer` 付きの Astro コンポーネントを直接使えないため、`LinkCard.astro` / `Amzn.astro` はラッパーで、KV と外部 API にアクセスする実体は `LinkCardServer.astro` / `AmznServer.astro`。PAAPI データは KV に 24 時間 TTL でキャッシュ。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Prettier は Edit / Write の PostToolUse フック（`.claude/settings.json`）
 
 記事本文で `<PositiveBox>` / `<NegativeBox>` を JSX として書くことはしない。ディレクティブを追加するときは `DIRECTIVES` へ1エントリ足し、レンダリング用の `.astro` を作って両方の `components` マップへ渡す。マップへの追加を忘れるとビルドが `Expected component ... to be defined` で落ちる。`test/unit/contentLint.test.ts` が記事の `:::` 名を `DIRECTIVES` と突き合わせ、`test/domain/postToMarkdown.test.ts` が全エントリの Markdown 変換を検証する。
 
-記事に書けるのは開始行 `:::positive`・終了行 `:::` の正規形（どちらも行頭・コロン3個）だけ。satteri は `::::positive`・字下げ・`:::positive{.tight}`・`:::positive[label]`・`::::` での閉じも解釈するが `postToMarkdown` は変換しないため、正規形以外は `/post/<slug>.md` に `:::` が露出する。非正規形は `test/unit/contentLint.test.ts` が開始行・終了行の両方で検出して失敗する。
+satteri が受け付ける記法（字下げ・コロン4個以上・開始終了のコロン数不一致・`:::positive{.tight}`・`:::positive[label]`・行末の余分なテキスト）は `postToMarkdown` も変換する。ネストと閉じ忘れだけは正規表現で扱えず `/post/<slug>.md` に `:::` が露出するため、`test/unit/contentLint.test.ts` が全 MDX を実際に `postToMarkdown` で変換して `:::` の残存を検出する。記事側の記法を制限するのではなく、このテストが落ちたら `postToMarkdown` を直す。
 
 MDX から `server:defer` 付きの Astro コンポーネントを直接使えないため、`LinkCard.astro` / `Amzn.astro` はラッパーで、KV と外部 API にアクセスする実体は `LinkCardServer.astro` / `AmznServer.astro`。PAAPI データは KV に 24 時間 TTL でキャッシュ。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,8 @@ Prettier は Edit / Write の PostToolUse フック（`.claude/settings.json`）
 
 記事本文で `<PositiveBox>` / `<NegativeBox>` を JSX として書くことはしない。ディレクティブを追加するときは `DIRECTIVES` へ1エントリ足し、レンダリング用の `.astro` を作って両方の `components` マップへ渡す。マップへの追加を忘れるとビルドが `Expected component ... to be defined` で落ちる。`test/unit/contentLint.test.ts` が記事の `:::` 名を `DIRECTIVES` と突き合わせ、`test/domain/postToMarkdown.test.ts` が全エントリの Markdown 変換を検証する。
 
+記事に書けるのは行頭・コロン3個・名前のみの正規形（`:::positive`）だけ。satteri は `::::positive`・字下げ・`:::positive{.tight}`・`:::positive[label]` も解釈するが `postToMarkdown` は変換しないため、正規形以外は `/post/<slug>.md` に `:::` が露出する。非正規形は `test/unit/contentLint.test.ts` が検出して失敗する。
+
 MDX から `server:defer` 付きの Astro コンポーネントを直接使えないため、`LinkCard.astro` / `Amzn.astro` はラッパーで、KV と外部 API にアクセスする実体は `LinkCardServer.astro` / `AmznServer.astro`。PAAPI データは KV に 24 時間 TTL でキャッシュ。
 
 ### Cloudflare Workers

--- a/src/lib/directives.ts
+++ b/src/lib/directives.ts
@@ -11,4 +11,4 @@ export const DIRECTIVES = {
 export type DirectiveName = keyof typeof DIRECTIVES
 
 export const isDirectiveName = (name: string): name is DirectiveName =>
-  name in DIRECTIVES
+  Object.hasOwn(DIRECTIVES, name)

--- a/src/lib/postToMarkdown.ts
+++ b/src/lib/postToMarkdown.ts
@@ -1,10 +1,34 @@
 import { DIRECTIVES, type DirectiveName } from "./directives"
 
-// :::positive ... ::: の1ブロック。ディレクティブ名はレジストリから生成する
+// :::positive ... ::: の1ブロック。ディレクティブ名はレジストリから生成する。
+// satteri が受け付ける字下げ・コロン4個以上・開始終了のコロン数不一致・ラベル
+// `[...]`・属性 `{...}`・行末の余分なテキストをすべて拾う。
+// 本文が空のブロックにも対応するため、本文側のグループを省略可能にしている。
 const directiveFencePattern = new RegExp(
-  `^:::(${Object.keys(DIRECTIVES).join("|")})[ \\t]*\\r?\\n([\\s\\S]*?)\\r?\\n:::[ \\t]*$`,
+  `^[ \\t]*:{3,}(${Object.keys(DIRECTIVES).join("|")})(?![\\w-])[^\\n]*(?:\\r?\\n([\\s\\S]*?))?\\r?\\n[ \\t]*:{3,}[^\\n]*$`,
   "gm"
 )
+
+/**
+ * ディレクティブ本文を引用ブロックへ変換する。
+ * 字下げされたブロックの本文はそのまま引用すると4スペース以上のインデントで
+ * コードブロック扱いになるため、共通の字下げ幅を除去する。
+ */
+const toQuotedBlock = (content: string): string => {
+  const lines = content.split("\n").map((line) => line.replace(/\r$/, ""))
+  while (lines.length > 0 && lines[0].trim() === "") lines.shift()
+  while (lines.length > 0 && lines[lines.length - 1].trim() === "") lines.pop()
+
+  const indents = lines
+    .filter((line) => line.trim() !== "")
+    .map((line) => line.length - line.trimStart().length)
+  const commonIndent = indents.length > 0 ? Math.min(...indents) : 0
+
+  return lines
+    .map((line) => line.slice(commonIndent))
+    .map((line) => (line.trim() === "" ? ">" : `> ${line}`))
+    .join("\n")
+}
 
 interface PostToMarkdownInput {
   slug: string
@@ -64,12 +88,10 @@ const transformSegment = (segment: string, partnerTag: string): string => {
   // 6. コンテナディレクティブ（:::positive / :::negative）→ 絵文字付き引用ブロック
   segment = segment.replace(
     directiveFencePattern,
-    (_, name: string, content: string) => {
-      const lines = content.trim().split("\n")
-      const quoted = lines.map((line) =>
-        line.trim() === "" ? ">" : `> ${line}`
-      )
-      return `${DIRECTIVES[name as DirectiveName].markdownPrefix}\n${quoted.join("\n")}`
+    (_, name: string, content: string | undefined) => {
+      const prefix = DIRECTIVES[name as DirectiveName].markdownPrefix
+      const quoted = toQuotedBlock(content ?? "")
+      return quoted === "" ? prefix : `${prefix}\n${quoted}`
     }
   )
 

--- a/test/domain/postToMarkdown.test.ts
+++ b/test/domain/postToMarkdown.test.ts
@@ -186,18 +186,45 @@ test("未定義のディレクティブ名は変換されない", () => {
   expect(result).toContain(":::warning")
 })
 
-// satteri は以下も container directive として解釈するが postToMarkdown は変換しない。
-// この非対称は contentLint.test.ts の正規形チェックで記事側を縛ることで防ぐ。
+// satteri が container directive として解釈する記法は、記事側で禁止せず
+// postToMarkdown 側で受け付ける
 test.each([
-  ["4個以上のコロン", "::::positive\n本文\n::::"],
+  ["コロン4個", "::::positive\n本文\n::::"],
+  ["開始終了のコロン数不一致", ":::positive\n本文\n::::"],
   ["属性付き", ":::positive{.tight}\n本文\n:::"],
   ["ラベル付き", ":::positive[見出し]\n本文\n:::"],
+  ["名前直後の余分なテキスト", ":::positive foo\n本文\n:::"],
   ["字下げ", "  :::positive\n  本文\n  :::"],
-  ["終了行のコロンが4個", ":::positive\n本文\n::::"],
-  ["終了行が字下げ", ":::positive\n本文\n  :::"]
-])("正規形以外（%s）は変換されない", (_label, body) => {
+  ["終了行のみ字下げ", ":::positive\n本文\n  :::"],
+  ["終了行の余分なテキスト", ":::positive\n本文\n::: end"],
+  ["本文が空", ":::positive\n:::"]
+])("satteri が受け付ける記法（%s）も変換される", (_label, body) => {
   const result = postToMarkdown({ ...BASE_INPUT, body })
-  expect(result).toContain(":::positive")
+  expect(result).toContain("> 😊")
+  expect(result).not.toContain(":::")
+})
+
+test("字下げされたブロックの本文は共通の字下げを除去して引用される", () => {
+  const body = "    :::positive\n    本文です\n      入れ子\n    :::"
+  const result = postToMarkdown({ ...BASE_INPUT, body })
+  expect(result).toContain("> 本文です")
+  expect(result).toContain(">   入れ子")
+})
+
+test("ディレクティブ名の部分一致（:::positively）は変換されない", () => {
+  const body = ":::positively\n本文\n:::"
+  const result = postToMarkdown({ ...BASE_INPUT, body })
+  expect(result).toContain(":::positively")
+})
+
+// 正規表現では扱えない範囲。記事側に現れないことは contentLint.test.ts の
+// 「全記事を変換して ::: が残らない」テストが保証する
+test.each([
+  ["閉じ忘れ", ":::positive\n本文"],
+  ["ネスト", ":::positive\n外\n::::negative\n内\n::::\n:::"]
+])("既知の未対応記法（%s）は ::: が残る", (_label, body) => {
+  const result = postToMarkdown({ ...BASE_INPUT, body })
+  expect(result).toContain(":::")
 })
 
 // === ルール7: 相対パス画像 ===

--- a/test/domain/postToMarkdown.test.ts
+++ b/test/domain/postToMarkdown.test.ts
@@ -192,7 +192,9 @@ test.each([
   ["4個以上のコロン", "::::positive\n本文\n::::"],
   ["属性付き", ":::positive{.tight}\n本文\n:::"],
   ["ラベル付き", ":::positive[見出し]\n本文\n:::"],
-  ["字下げ", "  :::positive\n  本文\n  :::"]
+  ["字下げ", "  :::positive\n  本文\n  :::"],
+  ["終了行のコロンが4個", ":::positive\n本文\n::::"],
+  ["終了行が字下げ", ":::positive\n本文\n  :::"]
 ])("正規形以外（%s）は変換されない", (_label, body) => {
   const result = postToMarkdown({ ...BASE_INPUT, body })
   expect(result).toContain(":::positive")

--- a/test/domain/postToMarkdown.test.ts
+++ b/test/domain/postToMarkdown.test.ts
@@ -186,6 +186,18 @@ test("未定義のディレクティブ名は変換されない", () => {
   expect(result).toContain(":::warning")
 })
 
+// satteri は以下も container directive として解釈するが postToMarkdown は変換しない。
+// この非対称は contentLint.test.ts の正規形チェックで記事側を縛ることで防ぐ。
+test.each([
+  ["4個以上のコロン", "::::positive\n本文\n::::"],
+  ["属性付き", ":::positive{.tight}\n本文\n:::"],
+  ["ラベル付き", ":::positive[見出し]\n本文\n:::"],
+  ["字下げ", "  :::positive\n  本文\n  :::"]
+])("正規形以外（%s）は変換されない", (_label, body) => {
+  const result = postToMarkdown({ ...BASE_INPUT, body })
+  expect(result).toContain(":::positive")
+})
+
 // === ルール7: 相対パス画像 ===
 
 test("相対パス画像 ![alt](./foo.jpg) が除去される", () => {

--- a/test/unit/contentLint.test.ts
+++ b/test/unit/contentLint.test.ts
@@ -36,12 +36,14 @@ test("LinkCardのprop誤記（小文字linkurl=）がMDXコンテンツに存在
 })
 
 // satteri は `::::name` / 字下げ / `:::name{...}` / `:::name[label]` / 名前直後の
-// 余分なテキストも container directive として受け付けるが、postToMarkdown の変換は
-// 行頭・コロン3個・名前のみの正規形しか拾わない。緩いパターンで開始行を集め、
-// 正規形かつ DIRECTIVES 定義済みであることを要求する。
+// 余分なテキスト / `::::` での閉じも container directive として受け付けるが、
+// postToMarkdown の変換は開始行・終了行ともに行頭・コロン3個の正規形しか拾わない。
+// 緩いパターンで両方を集め、正規形かつ DIRECTIVES 定義済みであることを要求する。
+// 開始行は名前あり、終了行は名前なしなので2つのパターンは重複しない。
 const directiveOpenerPattern = /^([ \t]*)(:{3,})([A-Za-z][A-Za-z0-9-]*)(.*)$/gm
+const directiveCloserPattern = /^([ \t]*)(:{3,})[ \t]*$/gm
 
-test("MDXのコンテナディレクティブが正規形かつ DIRECTIVES に定義されている", () => {
+test("MDXのディレクティブ開始行が正規形かつ DIRECTIVES に定義されている", () => {
   const offenders = Object.entries(allMdxSources).flatMap(([path, source]) =>
     [...source.matchAll(directiveOpenerPattern)]
       .filter(
@@ -51,6 +53,15 @@ test("MDXのコンテナディレクティブが正規形かつ DIRECTIVES に�
           rest.trim() !== "" ||
           !isDirectiveName(name)
       )
+      .map(([line]) => `${path}: ${JSON.stringify(line)}`)
+  )
+  expect(offenders).toEqual([])
+})
+
+test("MDXのディレクティブ終了行が正規形である", () => {
+  const offenders = Object.entries(allMdxSources).flatMap(([path, source]) =>
+    [...source.matchAll(directiveCloserPattern)]
+      .filter(([, indent, colons]) => indent !== "" || colons !== ":::")
       .map(([line]) => `${path}: ${JSON.stringify(line)}`)
   )
   expect(offenders).toEqual([])

--- a/test/unit/contentLint.test.ts
+++ b/test/unit/contentLint.test.ts
@@ -56,6 +56,18 @@ test("MDXで使われているディレクティブ名が DIRECTIVES に定義�
   expect(offenders).toEqual([])
 })
 
+// 下の変換テストが frontmatter を本文として扱っていないことの保証。
+// strip が空振りすると変換テストは緑のままカバレッジを失う
+test("全MDXから frontmatter を除去できている", () => {
+  const offenders = Object.entries(allMdxSources)
+    .filter(([, source]) => {
+      const stripped = stripFrontmatter(source)
+      return stripped === source || stripped.startsWith("---")
+    })
+    .map(([path]) => path)
+  expect(offenders).toEqual([])
+})
+
 // postToMarkdown はネストと閉じ忘れを変換できない。記法を禁止する代わりに、
 // 実際の記事を変換して ::: が残らないことで変換漏れを検出する
 test("全MDXを postToMarkdown で変換して ::: が残らない", () => {

--- a/test/unit/contentLint.test.ts
+++ b/test/unit/contentLint.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "vitest"
 import { DIRECTIVES, isDirectiveName } from "../../src/lib/directives"
+import { postToMarkdown } from "../../src/lib/postToMarkdown"
 
 // ビルド時(Vite)に全MDXソースを取り込む（workerd内ではfsを使えないため）
 const mdxSources = import.meta.glob("../../src/content/post/**/*.mdx", {
@@ -35,35 +36,45 @@ test("LinkCardのprop誤記（小文字linkurl=）がMDXコンテンツに存在
   expect(offenders).toEqual([])
 })
 
-// satteri は `::::name` / 字下げ / `:::name{...}` / `:::name[label]` / 名前直後の
-// 余分なテキスト / `::::` での閉じも container directive として受け付けるが、
-// postToMarkdown の変換は開始行・終了行ともに行頭・コロン3個の正規形しか拾わない。
-// 緩いパターンで両方を集め、正規形かつ DIRECTIVES 定義済みであることを要求する。
-// 開始行は名前あり、終了行は名前なしなので2つのパターンは重複しない。
-const directiveOpenerPattern = /^([ \t]*)(:{3,})([A-Za-z][A-Za-z0-9-]*)(.*)$/gm
-const directiveCloserPattern = /^([ \t]*)(:{3,})[ \t]*$/gm
+const stripCodeFences = (source: string): string =>
+  source.replace(/```[\s\S]*?```/g, "")
 
-test("MDXのディレクティブ開始行が正規形かつ DIRECTIVES に定義されている", () => {
+const stripFrontmatter = (source: string): string =>
+  source.replace(/^---\r?\n[\s\S]*?\r?\n---[ \t]*\r?\n/, "")
+
+// satteri は字下げ・コロン4個以上・ラベル・属性も container directive として
+// 受け付けるため、開始行の検出は緩いパターンで行う。終了行には名前がないので
+// このパターンとは重複しない
+const directiveOpenerPattern = /^[ \t]*:{3,}([A-Za-z][\w-]*)/gm
+
+test("MDXで使われているディレクティブ名が DIRECTIVES に定義されている", () => {
   const offenders = Object.entries(allMdxSources).flatMap(([path, source]) =>
-    [...source.matchAll(directiveOpenerPattern)]
-      .filter(
-        ([, indent, colons, name, rest]) =>
-          indent !== "" ||
-          colons !== ":::" ||
-          rest.trim() !== "" ||
-          !isDirectiveName(name)
-      )
+    [...stripCodeFences(source).matchAll(directiveOpenerPattern)]
+      .filter(([, name]) => !isDirectiveName(name))
       .map(([line]) => `${path}: ${JSON.stringify(line)}`)
   )
   expect(offenders).toEqual([])
 })
 
-test("MDXのディレクティブ終了行が正規形である", () => {
-  const offenders = Object.entries(allMdxSources).flatMap(([path, source]) =>
-    [...source.matchAll(directiveCloserPattern)]
-      .filter(([, indent, colons]) => indent !== "" || colons !== ":::")
-      .map(([line]) => `${path}: ${JSON.stringify(line)}`)
-  )
+// postToMarkdown はネストと閉じ忘れを変換できない。記法を禁止する代わりに、
+// 実際の記事を変換して ::: が残らないことで変換漏れを検出する
+test("全MDXを postToMarkdown で変換して ::: が残らない", () => {
+  const offenders = Object.entries(allMdxSources)
+    .map(([path, source]) => ({
+      path,
+      markdown: postToMarkdown({
+        slug: "test/slug",
+        title: "テスト",
+        date: new Date("2020-01-01T00:00:00Z"),
+        tags: ["TEST"],
+        body: stripFrontmatter(source),
+        siteUrl: "https://example.com/",
+        partnerTag: ""
+      })
+    }))
+    // コードフェンス内の ::: は変換対象外なので除外する
+    .filter(({ markdown }) => stripCodeFences(markdown).includes(":::"))
+    .map(({ path }) => path)
   expect(offenders).toEqual([])
 })
 

--- a/test/unit/contentLint.test.ts
+++ b/test/unit/contentLint.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest"
-import { DIRECTIVES } from "../../src/lib/directives"
+import { DIRECTIVES, isDirectiveName } from "../../src/lib/directives"
 
 // ビルド時(Vite)に全MDXソースを取り込む（workerd内ではfsを使えないため）
 const mdxSources = import.meta.glob("../../src/content/post/**/*.mdx", {
@@ -22,6 +22,12 @@ test("MDXコンテンツを1件以上読み込めている", () => {
   expect(Object.keys(mdxSources).length).toBeGreaterThan(0)
 })
 
+test("singlePageのMDXコンテンツも読み込めている", () => {
+  expect(Object.keys(allMdxSources).length).toBeGreaterThan(
+    Object.keys(mdxSources).length
+  )
+})
+
 test("LinkCardのprop誤記（小文字linkurl=）がMDXコンテンツに存在しない", () => {
   const offenders = Object.entries(mdxSources)
     .filter(([, source]) => /\blinkurl=/.test(source))
@@ -29,12 +35,23 @@ test("LinkCardのprop誤記（小文字linkurl=）がMDXコンテンツに存在
   expect(offenders).toEqual([])
 })
 
-test("MDXで使われているコンテナディレクティブが全て DIRECTIVES に定義されている", () => {
+// satteri は `::::name` / 字下げ / `:::name{...}` / `:::name[label]` / 名前直後の
+// 余分なテキストも container directive として受け付けるが、postToMarkdown の変換は
+// 行頭・コロン3個・名前のみの正規形しか拾わない。緩いパターンで開始行を集め、
+// 正規形かつ DIRECTIVES 定義済みであることを要求する。
+const directiveOpenerPattern = /^([ \t]*)(:{3,})([A-Za-z][A-Za-z0-9-]*)(.*)$/gm
+
+test("MDXのコンテナディレクティブが正規形かつ DIRECTIVES に定義されている", () => {
   const offenders = Object.entries(allMdxSources).flatMap(([path, source]) =>
-    [...source.matchAll(/^:::([a-z][a-z0-9-]*)/gm)]
-      .map((match) => match[1])
-      .filter((name) => !(name in DIRECTIVES))
-      .map((name) => `${path}: :::${name}`)
+    [...source.matchAll(directiveOpenerPattern)]
+      .filter(
+        ([, indent, colons, name, rest]) =>
+          indent !== "" ||
+          colons !== ":::" ||
+          rest.trim() !== "" ||
+          !isDirectiveName(name)
+      )
+      .map(([line]) => `${path}: ${JSON.stringify(line)}`)
   )
   expect(offenders).toEqual([])
 })
@@ -43,7 +60,7 @@ test("PositiveBox / NegativeBox がMDXでJSX記法として書かれていない
   const componentNames = Object.values(DIRECTIVES).map((d) => d.component)
   const offenders = Object.entries(allMdxSources).flatMap(([path, source]) =>
     componentNames
-      .filter((name) => new RegExp(`<${name}[\\s>]`).test(source))
+      .filter((name) => new RegExp(`<${name}[\\s/>]`).test(source))
       .map((name) => `${path}: <${name}>`)
   )
   expect(offenders).toEqual([])

--- a/test/unit/directives.test.ts
+++ b/test/unit/directives.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "vitest"
+import { DIRECTIVES, isDirectiveName } from "../../src/lib/directives"
+
+test("定義済みのディレクティブ名を受け付ける", () => {
+  for (const name of Object.keys(DIRECTIVES)) {
+    expect(isDirectiveName(name)).toBe(true)
+  }
+})
+
+test("未定義のディレクティブ名を拒否する", () => {
+  expect(isDirectiveName("warning")).toBe(false)
+})
+
+test("Object.prototype 由来のプロパティ名を拒否する", () => {
+  for (const name of ["toString", "constructor", "valueOf", "hasOwnProperty"]) {
+    expect(isDirectiveName(name)).toBe(false)
+  }
+})


### PR DESCRIPTION
PR #521 のレビュー指摘の反映。当初は記事側の記法を正規形へ縛る lint ゲートを入れていたが、satteri が提供する機能をリポジトリ側で暗黙的に無効化する形になるため、変換側（`postToMarkdown`）を satteri の受け入れ範囲へ寄せる方針に変更した。

## 変更内容

### `src/lib/directives.ts`

`isDirectiveName` の判定を `in` から `Object.hasOwn` へ変更。`in` はプロトタイプチェーンを辿るため `:::toString` がガードを通過し、`DIRECTIVES["toString"].component` が `undefined` の `mdxJsxFlowElement` を生成しうる。`test/unit/directives.test.ts` で `toString` / `constructor` / `valueOf` / `hasOwnProperty` を拒否することを検証。

### `src/lib/postToMarkdown.ts`

satteri が container directive として解釈する記法を変換するようにディレクティブのパターンを拡張した。

| 記法 | 変更前 | 変更後 |
| --- | --- | --- |
| 字下げ（開始行・終了行の任意の組み合わせ） | 非変換 | 変換 |
| コロン4個以上・開始終了のコロン数不一致 | 非変換 | 変換 |
| `:::positive[label]` / `:::positive{.tight}` | 非変換 | 変換 |
| 名前直後・終了行の余分なテキスト | 非変換 | 変換 |
| 本文が空のブロック | 非変換 | 変換 |
| ネスト・閉じ忘れ | 非変換 | 非変換（下記テストで検出） |

字下げされたブロックは本文の共通字下げ幅を除去する。除去しないと `> ` の後ろに4スペース以上が残り、引用内でコードブロック扱いになる。

ディレクティブ名の後に `(?![\w-])` を置き、`:::positively` が `positive` として部分一致しないようにした（satteri は名前を `positively` と解釈するため、変換しないのが正しい挙動）。

### `test/unit/contentLint.test.ts`

- 正規形を強制する開始行・終了行の2テストを削除
- 代替として、全 MDX（post / singlePage）を実際に `postToMarkdown` で変換し、コードフェンス外に `:::` が残らないことを検証するテストを追加。記事ソースではなく変換器を制約するため、記法を禁止せずに変換漏れを検出できる。副作用としてコードフェンス内にディレクティブ記法を書いた記事の誤検出もなくなる
- ディレクティブ名が `DIRECTIVES` に定義済みであることのチェックは維持。検出パターンを緩め（字下げ・コロン4個以上も対象）、コードフェンスを除外した
- JSX 記法チェックの文字クラスを `[\s>]` から `[\s/>]` へ修正（`<PositiveBox/>` を検出）
- singlePage の glob が実際に読み込めていることのアサーションを追加

## 検証

- `pnpm test:light` — 10 files / 117 tests passed
- `pnpm lint` — Prettier check 通過
- `pnpm lint:unused` — exit 0
- `pnpm build` — exit 0（473 ページ）
- ネガティブコントロール: `src/content/singlePage/external-data-policy.mdx` に閉じ忘れブロックを追記すると、残存検出テストが該当ファイル名を挙げて失敗することを確認（追記は revert 済み）
- ポジティブコントロール: 同ファイルに `  ::::positive[見出し]` の字下げ・コロン4個・ラベル付きブロックを追記した状態でテストが通ることを確認（追記は revert 済み）
